### PR TITLE
fix cmd .sol extension missing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1320,7 +1320,7 @@ https://twitter.com/BlockSecTeam/status/1529084919976034304
 buys vault token -> redeems NFTs -> claims airdrop of 60k APE -> re-supply's the pool
 Testing
 ```sh
-forge test --contracts ./src/test/Bayc_apecoin_exp -vvv
+forge test --contracts ./src/test/Bayc_apecoin_exp.sol -vvv
 ```
 #### Contract
 


### PR DESCRIPTION
if .sol extension is missing in command, it could cause: 👇🏻

```
➜  DeFiHackLabs git:(main) forge test --contracts ./src/test/Bayc_apecoin_exp -vvv    
[⠢] Compiling...
[⠆] Compiling 6 files with 0.8.17
[⠰] Solc 0.8.17 finished in 1.06s
Compiler run successful

No tests found in project! Forge looks for functions that starts with `test`.
```