### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Reproduce DeFi hack incidents using Foundry.**
 
-272 incidents included.
+273 incidents included.
 
 Let's make Web3 secure! Join [Discord](https://discord.gg/Fjyngakf3h)
 
@@ -482,8 +482,6 @@ All articles are also published on [Substack](https://defihacklabs.substack.com/
 
 [20220329 Redacted Cartel](#20220329-redacted-cartel---custom-approval-logic)
 
-[20220328 SafeMoon Hack](#20230328-safemoon-hack)
-
 [20220327 Revest Finance](#20220327-revest-finance---reentrancy)
 
 [20220326 Auctus](#20220326-auctus)
@@ -567,11 +565,6 @@ All articles are also published on [Substack](https://defihacklabs.substack.com/
 
 [20210519 PancakeBunny](#20210519-pancakebunny---price-oracle-manipulation)
 
-[20210125 Sushi Badger Digg](#20210125-sushi-badger-digg---sandwich-attack)
-
-</details>
-<details> <summary> Before 2020 </summary>
-
 [20210508 Rari Capital](#20210509-raricapital---cross-contract-reentrancy)
 
 [20210508 Value Defi](#20210508-value-defi---cross-contract-reentrancy)
@@ -581,6 +574,11 @@ All articles are also published on [Substack](https://defihacklabs.substack.com/
 [20210308 DODO](#20210308-dodo---flashloan-attack)
 
 [20210305 Paid Network](#20210305-paid-network---private-key-compromised)
+
+[20210125 Sushi Badger Digg](#20210125-sushi-badger-digg---sandwich-attack)
+
+</details>
+<details> <summary> Before 2020 </summary>
 
 [20201229 Cover Protocol](#20201229-cover-protocol)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Reproduce DeFi hack incidents using Foundry.**
 
-273 incidents included.
+276 incidents included.
 
 Let's make Web3 secure! Join [Discord](https://discord.gg/Fjyngakf3h)
 

--- a/past/2021/README.md
+++ b/past/2021/README.md
@@ -2,7 +2,7 @@
 
 ## Before 2021 - List of Past DeFi Incidents
 
-36 incidents included.
+37 incidents included.
 
 [20211221 Visor Finance](#20211221-visor-finance---reentrancy)
 

--- a/past/2021/README.md
+++ b/past/2021/README.md
@@ -2,6 +2,8 @@
 
 ## Before 2021 - List of Past DeFi Incidents
 
+36 incidents included.
+
 [20211221 Visor Finance](#20211221-visor-finance---reentrancy)
 
 [20211218 Grim Finance](#20211218-grim-finance---flashloan--reentrancy)
@@ -50,8 +52,6 @@
 
 [20210519 PancakeBunny](#20210519-pancakebunny---price-oracle-manipulation)
 
-[20210125 Sushi Badger Digg](#20210125-sushi-badger-digg---sandwich-attack)
- 
 [20210508 Rari Capital](#20210509-raricapital---cross-contract-reentrancy)
 
 [20210508 Value Defi](#20210508-value-defi---cross-contract-reentrancy)
@@ -61,6 +61,8 @@
 [20210308 DODO](#20210308-dodo---flashloan-attack)
 
 [20210305 Paid Network](#20210305-paid-network---private-key-compromised)
+
+[20210125 Sushi Badger Digg](#20210125-sushi-badger-digg---sandwich-attack)
 
 [20201229 Cover Protocol](#20201229-cover-protocol)
 

--- a/past/2022/README.md
+++ b/past/2022/README.md
@@ -2,6 +2,8 @@
 
 ## 2022 - List of Past DeFi Incidents
 
+118 incidents included.
+
 [20221230 DFS](#20221230---dfs---insufficient-validation--flashloan)
 
 [20221229 JAY](#20221229---jay---insufficient-validation--reentrancy)

--- a/past/2022/README.md
+++ b/past/2022/README.md
@@ -2,7 +2,7 @@
 
 ## 2022 - List of Past DeFi Incidents
 
-118 incidents included.
+119 incidents included.
 
 [20221230 DFS](#20221230---dfs---insufficient-validation--flashloan)
 


### PR DESCRIPTION
I've made several updates to the project's README. Specifically, I removed redundant information about the SAFEMOON hack incident in the 2022 section. Additionally, I reordered the incidents in the 2021 section to reflect chronological order and fixed the issue of some incidents being categorized under incorrect year labels in the README. Lastly, I recalculated and updated the incident counts: 120 incidents for 2023, 119 incidents for 2022, and 37 incidents for 2021 and earlier. So there seem to be a total of 276 incidents now.