### PR TITLE
Added rpc.sol file for improving convenience

### DIFF
--- a/src/Poc-template.sol
+++ b/src/Poc-template.sol
@@ -25,7 +25,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     
     function setUp() public {
-        cheats.createSelectFork("mainnet", 15460093);
+        cheats.createSelectFork(eth, 15460093);
         cheats.label(address(USDT), "USDT");
         cheats.label(address(USDC), "USDC");
         //address alice = makeAddr("alice");

--- a/src/test/0vix_exp.sol
+++ b/src/test/0vix_exp.sol
@@ -93,7 +93,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("polygon", 42_054_768);
+        cheats.createSelectFork(polygon, 42_054_768);
         cheats.label(address(GHST), "GHST");
         cheats.label(address(USDC), "USDC");
         cheats.label(address(USDT), "USDT");

--- a/src/test/0x0DEX_exp.sol
+++ b/src/test/0x0DEX_exp.sol
@@ -93,7 +93,7 @@ contract ContractTest is Test {
         0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001;
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 18115707);
+        vm.createSelectFork(eth, 18115707);
         vm.label(address(OxODexPool), "OxODexPool");
         vm.label(address(WETH), "WETH");
         vm.label(address(USDC), "USDC");

--- a/src/test/88mph_exp.sol
+++ b/src/test/88mph_exp.sol
@@ -9,7 +9,7 @@ contract ContractTest is DSTest {
     I88mph mphNFT = I88mph(0xF0b7DE03134857391d8D43Ed48e20EDF21461097);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 12_516_705); //fork mainnet at block 13715025
+        cheats.createSelectFork(eth, 12_516_705); //fork mainnet at block 13715025
     }
 
     function testExploit() public {

--- a/src/test/AES_exp.sol
+++ b/src/test/AES_exp.sol
@@ -24,7 +24,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 23_695_904);
+        cheats.createSelectFork(bsc, 23_695_904);
     }
 
     function testExploit() public {

--- a/src/test/ANCH_exp.sol
+++ b/src/test/ANCH_exp.sol
@@ -19,7 +19,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 20_302_534);
+        cheats.createSelectFork(bsc, 20_302_534);
     }
 
     function testExploit() public {

--- a/src/test/APC_exp.sol
+++ b/src/test/APC_exp.sol
@@ -25,7 +25,7 @@ contract ContractTest is DSTest{
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 23527906);
+        cheats.createSelectFork(bsc, 23527906);
     }
 
     function testExploit() public{

--- a/src/test/APIG_exp.sol
+++ b/src/test/APIG_exp.sol
@@ -55,7 +55,7 @@ contract ContractTest is Test {
     address[] path = new address[](2);
 
     function setUp() public {
-        vm.createSelectFork("bsc", 31562012 - 1);
+        vm.createSelectFork(bsc, 31562012 - 1);
         vm.label(address(aDaDPair), "0xadad_Pair");
         vm.label(address(EfBfPair), "0xefbf_Pair");
         vm.label(address(b920Pair), "0xb920_Pair");

--- a/src/test/ARA_exp.sol
+++ b/src/test/ARA_exp.sol
@@ -38,7 +38,7 @@ contract ARATest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 29_214_010);
+        cheats.createSelectFork(bsc, 29_214_010);
         cheats.label(address(BUSDT), "BUSDT");
         cheats.label(address(ARA), "ARA");
         cheats.label(address(Router), "Router");

--- a/src/test/ATK_exp.sol
+++ b/src/test/ATK_exp.sol
@@ -25,7 +25,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 22_102_838);
+        cheats.createSelectFork(bsc, 22_102_838);
     }
 
     function testExploit() public {

--- a/src/test/AUR_exp.sol
+++ b/src/test/AUR_exp.sol
@@ -35,7 +35,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 23_282_134);
+        cheats.createSelectFork(bsc, 23_282_134);
         cheats.deal(address(this), 0.01 ether);
     }
 

--- a/src/test/AkutarNFT_exp.sol
+++ b/src/test/AkutarNFT_exp.sol
@@ -21,7 +21,7 @@ contract AkutarNFTExploit is DSTest {
     IAkutarNFT akutarNft = IAkutarNFT(0xF42c318dbfBaab0EEE040279C6a2588Fa01a961d);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 14636844); // fork mainnet at 14636844 
+        cheats.createSelectFork(eth, 14636844); // fork mainnet at 14636844 
     }
 
     function testDOSAttack() public {

--- a/src/test/Allbridge_exp.sol
+++ b/src/test/Allbridge_exp.sol
@@ -33,7 +33,7 @@ interface IBridge {
 
 contract ContractTest is Test {
     function setUp() external {
-        vm.createSelectFork("bsc", 26_982_067);
+        vm.createSelectFork(bsc, 26_982_067);
     }
 
     function test_exploit() external {

--- a/src/test/Allbridge_exp2.sol
+++ b/src/test/Allbridge_exp2.sol
@@ -46,7 +46,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 26_982_067);
+        cheats.createSelectFork(bsc, 26_982_067);
         cheats.label(address(BUSD), "BUSD");
         cheats.label(address(USDT), "USDT");
         cheats.label(address(BridgeSwap), "BridgeSwap");

--- a/src/test/Annex_exp.sol
+++ b/src/test/Annex_exp.sol
@@ -22,7 +22,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 23_165_446);
+        cheats.createSelectFork(bsc, 23_165_446);
     }
 
     function testExploit() public {

--- a/src/test/Anyswap_poc.t.sol
+++ b/src/test/Anyswap_poc.t.sol
@@ -12,7 +12,7 @@ contract ContractTest is DSTest {
     WETH weth = WETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 14_037_236); // fork mainnet block number 14037236
+        cheats.createSelectFork(eth, 14_037_236); // fork mainnet block number 14037236
     }
 
     function testExample() public {

--- a/src/test/ApeDAO_exp.sol
+++ b/src/test/ApeDAO_exp.sol
@@ -36,7 +36,7 @@ contract ApeDAOTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 30072293);
+        cheats.createSelectFork(bsc, 30072293);
         cheats.label(address(BUSDT), "BUSDT");
         cheats.label(address(APEDAO), "APEDAO");
         cheats.label(address(DPPOracle1), "DPPOracle1");

--- a/src/test/ArcadiaFi_exp.sol
+++ b/src/test/ArcadiaFi_exp.sol
@@ -69,7 +69,7 @@ contract ContractTest is Test {
     IVault Proxy2;
 
     function setUp() public {
-        vm.createSelectFork("optimism", 106_676_494);
+        vm.createSelectFork(optimism, 106_676_494);
         vm.label(address(USDC), "USDC");
         vm.label(address(WETH), "WETH");
         vm.label(address(aaveV3), "aaveV3");

--- a/src/test/Auctus_exp.sol
+++ b/src/test/Auctus_exp.sol
@@ -37,7 +37,7 @@ contract ContractTest is DSTest, MockACOToken {
     IERC20 usdc = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 14_460_635); // fork mainnet at block 14460635
+        cheats.createSelectFork(eth, 14_460_635); // fork mainnet at block 14460635
     }
 
     function test() public {

--- a/src/test/Audius.exp.sol
+++ b/src/test/Audius.exp.sol
@@ -61,7 +61,7 @@ contract AttackContract is Test {
     address constant weth = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
     function setUp() public {
-        cheat.createSelectFork("mainnet", 15201793);    // Fork mainnet at block 15201793
+        cheat.createSelectFork(eth, 15201793);    // Fork mainnet at block 15201793
         cheat.label(AUDIO, "AUDIO");
         cheat.label(uniswap, "UniswapV2Router02");
         cheat.label(governance, "GovernanceProxy");

--- a/src/test/Axioma_exp.sol
+++ b/src/test/Axioma_exp.sol
@@ -24,7 +24,7 @@ contract ContractTest is Test {
     address wbnb_usdt_b = 0xFeAFe253802b77456B4627F8c2306a9CeBb5d681; // dodo wbnb-usdt pool
 
     function setUp() public {
-        vm.createSelectFork("bsc", 27_620_321 - 1);
+        vm.createSelectFork(bsc, 27_620_321 - 1);
     }
 
     function testExploit() public {

--- a/src/test/AzukiDAO_exp.sol
+++ b/src/test/AzukiDAO_exp.sol
@@ -33,7 +33,7 @@ contract AzukiTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 17_593_308);
+        cheats.createSelectFork(eth, 17_593_308);
         cheats.label(address(AZUKI), "AZUKI");
         cheats.label(address(Bean), "Bean");
         cheats.label(Elemental, "Elemental");

--- a/src/test/BBOX_exp.sol
+++ b/src/test/BBOX_exp.sol
@@ -20,7 +20,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 23_106_506);
+        cheats.createSelectFork(bsc, 23_106_506);
     }
 
     function testExploit() public {

--- a/src/test/BDEX_exp.sol
+++ b/src/test/BDEX_exp.sol
@@ -29,7 +29,7 @@ contract ContractTest is DSTest {
 
     function setUp() public {
         // the ankr rpc maybe dont work , please use QuickNode
-        cheats.createSelectFork("bsc", 22_629_431);
+        cheats.createSelectFork(bsc, 22_629_431);
     }
 
     function testExploit() public {

--- a/src/test/BEC_exp.sol
+++ b/src/test/BEC_exp.sol
@@ -20,7 +20,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 5_483_642);
+        cheats.createSelectFork(eth, 5_483_642);
     }
 
     function testExploit() public {

--- a/src/test/BEGO_exp.sol
+++ b/src/test/BEGO_exp.sol
@@ -22,7 +22,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 22_315_679);
+        cheats.createSelectFork(bsc, 22_315_679);
     }
 
     function testExploit() public {

--- a/src/test/BFCToken_exp.sol
+++ b/src/test/BFCToken_exp.sol
@@ -25,7 +25,7 @@ contract BFCTest is Test {
     IERC20 WBNB = IERC20(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
 
     function setUp() public {
-        vm.createSelectFork("bsc", 31599443);
+        vm.createSelectFork(bsc, 31599443);
         vm.label(address(BUSDT_WBNB), "BUSDT_WBNB");
         vm.label(address(BUSDT_BFC), "BUSDT_BFC");
         vm.label(address(Router), "Router");

--- a/src/test/BGLD_exp.sol
+++ b/src/test/BGLD_exp.sol
@@ -29,7 +29,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 23_844_529);
+        cheats.createSelectFork(bsc, 23_844_529);
     }
 
     function testExploit() public {

--- a/src/test/BH_exp.sol
+++ b/src/test/BH_exp.sol
@@ -49,7 +49,7 @@ contract ContractTest is Test {
         0x2371E4Ad771020CE3D8252f1db3e5559FbA8eeb5;
 
     function setUp() public {
-        vm.createSelectFork("bsc", 32512073);
+        vm.createSelectFork(bsc, 32512073);
         vm.label(address(BUSDT), "BUSDT");
         vm.label(address(BH), "BH");
         vm.label(address(DPPOracle1), "DPPOracle1");

--- a/src/test/BIGFI_exp.sol
+++ b/src/test/BIGFI_exp.sol
@@ -29,7 +29,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 26_685_503);
+        cheats.createSelectFork(bsc, 26_685_503);
         cheats.label(address(BIGFI), "BIGFI");
         cheats.label(address(USDT), "USDT");
         cheats.label(address(swapFlashLoan), "swapFlashLoan");

--- a/src/test/BNB48MEVBot_exp.sol
+++ b/src/test/BNB48MEVBot_exp.sol
@@ -18,7 +18,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 21_297_409);
+        cheats.createSelectFork(bsc, 21_297_409);
     }
 
     function testExploit() public {

--- a/src/test/BNO_exp.sol
+++ b/src/test/BNO_exp.sol
@@ -37,7 +37,7 @@ contract BNOTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 30056629);
+        cheats.createSelectFork(bsc, 30056629);
         cheats.label(address(NFT), "NFT");
         cheats.label(address(BNO), "BNO");
         cheats.label(address(PancakePair), "PancakePair");

--- a/src/test/BRA.exp.sol
+++ b/src/test/BRA.exp.sol
@@ -31,7 +31,7 @@ contract Attacker is Test {
     WBNB constant wbnb = WBNB(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
     Exploit immutable exploit;
     constructor() {
-        vm.createSelectFork("bsc", 24655771);
+        vm.createSelectFork(bsc, 24655771);
         exploit = new Exploit();
     }
 

--- a/src/test/BTC20_exp.sol
+++ b/src/test/BTC20_exp.sol
@@ -31,7 +31,7 @@ contract ContractTest is Test {
     uint totalBorrowed = 300 ether;
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 17_949_215 - 1);
+        vm.createSelectFork(eth, 17_949_215 - 1);
         vm.label(address(BTC20), "BTC20");
         vm.label(address(WETH), "WETH");
         vm.label(address(SDEX), "SDEX");

--- a/src/test/BUNN_exp.sol
+++ b/src/test/BUNN_exp.sol
@@ -24,7 +24,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() external {
-        cheats.createSelectFork("bsc", 29_304_627);
+        cheats.createSelectFork(bsc, 29_304_627);
     }
 
     function testExploit() external {

--- a/src/test/BXH_exp.sol
+++ b/src/test/BXH_exp.sol
@@ -27,7 +27,7 @@ contract Attacker is Test {
         TokenStakingPoolDelegate(0x27539B1DEe647b38e1B987c41C5336b1A8DcE663);
 
     function setUp() public {
-        cheat.createSelectFork("bsc", 21_727_289);
+        cheat.createSelectFork(bsc, 21_727_289);
         cheat.label(address(BXH), "BXH");
         cheat.label(address(usdt), "USDT");
         cheat.label(address(wbnb), "WBNB");

--- a/src/test/BabyDogeCoin02_exp.sol
+++ b/src/test/BabyDogeCoin02_exp.sol
@@ -65,7 +65,7 @@ contract ContractTest is Test {
     uint256 BUSDFlashLoanAmount;
 
     function setUp() public {
-        vm.createSelectFork("bsc", 29_295_010);
+        vm.createSelectFork(bsc, 29_295_010);
         vm.label(address(BUSD), "BUSD");
         vm.label(address(USDT), "USDT");
         vm.label(address(WBNB), "WBNB");

--- a/src/test/BabyDogeCoin_exp.sol
+++ b/src/test/BabyDogeCoin_exp.sol
@@ -43,7 +43,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 28_593_354);
+        cheats.createSelectFork(bsc, 28_593_354);
         cheats.label(address(WBNB), "WBNB");
         cheats.label(address(BABYDOGE), "BABYDOGE");
         cheats.label(address(Pair), "Pair");

--- a/src/test/BabySwap_exp.sol
+++ b/src/test/BabySwap_exp.sol
@@ -61,7 +61,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 21_811_979);
+        cheats.createSelectFork(bsc, 21_811_979);
     }
 
     function testExploit() public {

--- a/src/test/Bacon_exp.sol
+++ b/src/test/Bacon_exp.sol
@@ -13,7 +13,7 @@ contract ContractTest is DSTest {
     uint256 count = 0;
 
     constructor() {
-        cheats.createSelectFork("mainnet", 14_326_931); // fork mainnet at block 14326931
+        cheats.createSelectFork(eth, 14_326_931); // fork mainnet at block 14326931
 
         ERC1820Registry(0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24).setInterfaceImplementer(
             address(this), bytes32(0xb281fc8c12954d22544db45de3159a39272895b169a852b314f9cc762e44c53b), address(this)

--- a/src/test/BadGuysbyRPF_exp.sol
+++ b/src/test/BadGuysbyRPF_exp.sol
@@ -25,7 +25,7 @@ contract BadGuysbyRPFExploit is DSTest {
     bytes32[] merkleTree;
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 15_460_093); //fork mainnet at 15460093
+        cheats.createSelectFork(eth, 15_460_093); //fork mainnet at 15460093
 
         // There should be an easier way to do this
         // I tried passing it as whole array but did not work

--- a/src/test/Balancer_exp.sol
+++ b/src/test/Balancer_exp.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.10;
 
 import "forge-std/console.sol";
 import "forge-std/Test.sol";
-import "../test/interface.sol";
+import "./interface.sol";
 
 // @KeyInfo - Total Lost : ~2M
 // Attacker : https://etherscan.io/address/0xed187f37e5ad87d5b3b2624c01de56c5862b7a9b
@@ -39,7 +39,7 @@ contract ContractTest is Test {
     IERC20 bbaUSD = IERC20(0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2);
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 18_004_651);
+        vm.createSelectFork(eth, 18_004_651);
         vm.label(address(USDT), "USDT");
         vm.label(address(USDC), "USDC");
         vm.label(address(DAI), "DAI");

--- a/src/test/Bamboo_exp.sol
+++ b/src/test/Bamboo_exp.sol
@@ -30,7 +30,7 @@ contract BambooTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 29_668_034);
+        cheats.createSelectFork(bsc, 29_668_034);
 
         vm.label(address(wbnb), "WBNB");
         vm.label(address(bamboo), "BAMBOO");

--- a/src/test/Bancor_exp.sol
+++ b/src/test/Bancor_exp.sol
@@ -29,7 +29,7 @@ contract BancorExploit is DSTest {
     IBancor bancorContract = IBancor(bancorAddress);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 10_307_563); // fork mainnet at 10307563
+        cheats.createSelectFork(eth, 10_307_563); // fork mainnet at 10307563
     }
 
     function testsafeTransfer() public {

--- a/src/test/Bao_exp.sol
+++ b/src/test/Bao_exp.sol
@@ -51,7 +51,7 @@ contract ContractTest is Test {
     IAaveFlashloan AaveV2 = IAaveFlashloan(0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9);
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 17_620_870);
+        vm.createSelectFork(eth, 17_620_870);
         vm.label(address(USDC), "USDC");
         vm.label(address(DAI), "DAI");
         vm.label(address(aDAI), "aDAI");

--- a/src/test/Bayc_apecoin_exp.sol
+++ b/src/test/Bayc_apecoin_exp.sol
@@ -20,7 +20,7 @@ contract ContractTest is DSTest {
     bytes32 private constant CALLBACK_SUCCESS = keccak256("ERC3156FlashBorrower.onFlashLoan");
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 14_403_948); // fork mainnet at block 14403948
+        cheats.createSelectFork(eth, 14_403_948); // fork mainnet at block 14403948
     }
 
     function test() public {

--- a/src/test/Beanstalk_exp.sol
+++ b/src/test/Beanstalk_exp.sol
@@ -29,7 +29,7 @@ contract ContractTest is DSTest {
   uint32 bip = 18;
 
   constructor() {
-    cheat.createSelectFork("mainnet", 14595905); // fork mainnet at block 14595905
+    cheat.createSelectFork(eth, 14595905); // fork mainnet at block 14595905
   }
 
   function testExploit() public {

--- a/src/test/BelugaDex_exp.sol
+++ b/src/test/BelugaDex_exp.sol
@@ -64,7 +64,7 @@ contract ContractTest is Test {
         IPancakeRouter(payable(0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506));
 
     function setUp() public {
-        vm.createSelectFork("arbitrum", 140129166);
+        vm.createSelectFork(arbitrum, 140129166);
         vm.label(address(USDT), "USDT");
         vm.label(address(USDCe), "USDCe");
         vm.label(address(WETH), "WETH");

--- a/src/test/Biswap_exp.sol
+++ b/src/test/Biswap_exp.sol
@@ -169,7 +169,7 @@ contract ContractTest is Test {
 
     function setUp() public {
         // fork bsc
-        uint256 forkId = vm.createFork("bsc", 29554461);
+        uint256 forkId = vm.createFork(bsc, 29554461);
         vm.selectFork(forkId);
     }
 

--- a/src/test/Bitpaidio_exp.sol
+++ b/src/test/Bitpaidio_exp.sol
@@ -31,7 +31,7 @@ contract ContractTest is Test {
     uint256 flashAmount = 219_349 * 1e18;
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 28_176_675);
+        cheats.createSelectFork(bsc, 28_176_675);
     }
 
     function testExploit() public {

--- a/src/test/BonqDAO_exp.sol
+++ b/src/test/BonqDAO_exp.sol
@@ -53,7 +53,7 @@ contract Attacker is Test {
 
     function testExploit() public {
         // Full simulation, run Tx1 and Tx2
-        vm.createSelectFork("polygon", 38792977);
+        vm.createSelectFork(polygon, 38792977);
         exploit = new Exploit();
 
         // Pre-works, check out: https://polygonscan.com/address/0xed596991ac5f1aa1858da66c67f7cfa76e54b5f1#tokentxns
@@ -74,7 +74,7 @@ contract Attacker is Test {
 
     function testAttackTx1() public {
         // Only run attack Tx1
-        vm.createSelectFork("polygon", 38792977);        
+        vm.createSelectFork(polygon, 38792977);        
         exploit = new Exploit();
 
         deal(address(TRB), address(exploit), 10e18);
@@ -88,7 +88,7 @@ contract Attacker is Test {
 
     function testAttackTx2() public {
         // Only run attack Tx2
-        vm.createSelectFork("polygon", 38793028);        
+        vm.createSelectFork(polygon, 38793028);        
         exploit = new Exploit();
 
         deal(address(TRB), address(exploit), 20e18);

--- a/src/test/BrahTOPG_exp.sol
+++ b/src/test/BrahTOPG_exp.sol
@@ -31,7 +31,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 15_933_794);
+        cheats.createSelectFork(eth, 15_933_794);
     }
 
     function testExploit() public {

--- a/src/test/BuildF_exp.sol
+++ b/src/test/BuildF_exp.sol
@@ -11,7 +11,7 @@ contract ContractTest is DSTest {
     IERC20 build = IERC20(0x6e36556B3ee5Aa28Def2a8EC3DAe30eC2B208739);
 
     function setUp() public {
-        cheat.createSelectFork("mainnet", 14_235_712); // fork mainnet at block 14235712
+        cheat.createSelectFork(eth, 14_235_712); // fork mainnet at block 14235712
     }
 
     function test() public {

--- a/src/test/BurgerSwap_exp.sol
+++ b/src/test/BurgerSwap_exp.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.17;
 
 import "forge-std/Test.sol";
+import "./interface.sol";
 
 // Attacker: 0x6c9f2b95ca3432e5ec5bcd9c19de0636a23a4994
 // Attack Contract: 0xae0f538409063e66ff0e382113cb1a051fc069cd
@@ -25,7 +26,7 @@ contract Exploit is Test {
     FAKE_TOKEN FAKE;
 
     function setUp() public {
-        vm.createSelectFork("bsc", 7_781_159);
+        vm.createSelectFork(bsc, 7_781_159);
     }
 
     function testExploit() public {
@@ -136,12 +137,6 @@ contract FAKE_TOKEN {
 }
 
 /* ---------------------- Interface ---------------------- */
-interface IERC20 {
-    function transfer(address to, uint256 amount) external returns (bool);
-    function approve(address spender, uint256 amount) external returns (bool);
-    function balanceOf(address account) external view returns (uint256);
-    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
-}
 
 interface IDemaxPlatform {
     function swapExactTokensForTokens(
@@ -171,11 +166,4 @@ interface IDemaxDelegate {
         uint256 amountBMin,
         uint256 deadline
     ) external returns (uint256 amountA, uint256 amountB, uint256 liquidity);
-}
-
-interface IUniswapV2Pair {
-    function balanceOf(address) external view returns (uint256);
-    function skim(address to) external;
-    function sync() external;
-    function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes memory data) external;
 }

--- a/src/test/CEXISWAP_exp.sol
+++ b/src/test/CEXISWAP_exp.sol
@@ -37,7 +37,7 @@ contract CexiTest is Test {
     Exploiter private exploiter;
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 18182605);
+        vm.createSelectFork(eth, 18182605);
         vm.label(address(CEXISWAP), "CEXISWAP");
         vm.label(address(USDT), "USDT");
     }

--- a/src/test/CFC_exp.sol
+++ b/src/test/CFC_exp.sol
@@ -25,7 +25,7 @@ contract CFCTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 29_116_478);
+        cheats.createSelectFork(bsc, 29_116_478);
         cheats.label(address(BEP20USDT), "BEP20USDT");
         cheats.label(address(SAFE), "SAFE");
         cheats.label(address(CFC), "CFC");

--- a/src/test/CIVNFT_exp.sol
+++ b/src/test/CIVNFT_exp.sol
@@ -47,7 +47,7 @@ contract CIVNFTTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 17649875);
+        cheats.createSelectFork(eth, 17649875);
         cheats.label(address(CIV), "CIV");
         cheats.label(address(WETH), "WETH");
         cheats.label(CIVNFT, "CIVNFT");

--- a/src/test/CS_exp.sol
+++ b/src/test/CS_exp.sol
@@ -23,7 +23,7 @@ contract CSExp is Test, IPancakeCallee {
     IERC20 CS = IERC20(0x8BC6Ce23E5e2c4f0A96429E3C9d482d74171215e);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 28466976);
+        cheats.createSelectFork(bsc, 28466976);
         
     }
 

--- a/src/test/Carrot_exp.sol
+++ b/src/test/Carrot_exp.sol
@@ -85,7 +85,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 22_055_611); // fork bsc at block 22055611
+        cheats.createSelectFork(bsc, 22_055_611); // fork bsc at block 22055611
         cheats.label(address(Carrot), "Carrot");
         cheats.label(address(Router), "Router");
         cheats.label(address(0x6863b549bf730863157318df4496eD111aDFA64f), "Pool");

--- a/src/test/Carson_exp.sol
+++ b/src/test/Carson_exp.sol
@@ -28,7 +28,7 @@ contract CarsonTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 30_306_324);
+        cheats.createSelectFork(bsc, 30_306_324);
         cheats.label(address(BUSDT), "BUSDT");
         cheats.label(address(Carson), "Carson");
         cheats.label(address(DPPOracle1), "DPPOracle1");

--- a/src/test/Cellframe_exp.sol
+++ b/src/test/Cellframe_exp.sol
@@ -50,7 +50,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 28_708_273);
+        cheats.createSelectFork(bsc, 28_708_273);
         cheats.label(address(DPPOracle), "DPPOracle");
         cheats.label(address(PancakePool), "PancakePool");
         cheats.label(address(Router), "Router");

--- a/src/test/Chainswap_exp1.sol
+++ b/src/test/Chainswap_exp1.sol
@@ -24,7 +24,7 @@ contract ContractTest is DSTest {
   CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
   function setUp() public {
-    cheats.createSelectFork("mainnet", 12751487); // fork mainnet at block 13125070
+    cheats.createSelectFork(eth, 12751487); // fork mainnet at block 13125070
     // https://etherscan.io/tx/0x5c5688a9f981a07ed509481352f12f22a4bd7cea46a932c6d6bbe67cca3c54be
   }
 

--- a/src/test/Chainswap_exp2.sol
+++ b/src/test/Chainswap_exp2.sol
@@ -24,7 +24,7 @@ contract ContractTest is DSTest {
   CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
   function setUp() public {
-    cheats.createSelectFork("bsc", 9042274); // fork mainnet at block 13125070   
+    cheats.createSelectFork(bsc, 9042274); // fork mainnet at block 13125070   
   }
 
   function testExploit() public {

--- a/src/test/Civfund_exp.sol
+++ b/src/test/Civfund_exp.sol
@@ -102,7 +102,7 @@ contract ContractTest is Test {
     uint256 private counter = 0;
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 17_646_141);
+        cheats.createSelectFork(eth, 17_646_141);
         cheats.label(address(USDT), "USDT");
         cheats.label(address(BONE), "BONE");
         cheats.label(address(LEASH), "LEASH");

--- a/src/test/CompoundTusd_exp.sol
+++ b/src/test/CompoundTusd_exp.sol
@@ -11,7 +11,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 14_266_479); // fork mainnet at block 14266479
+        cheats.createSelectFork(eth, 14_266_479); // fork mainnet at block 14266479
     }
 
     function testExample() public {

--- a/src/test/CompounderFinance_exp.sol
+++ b/src/test/CompounderFinance_exp.sol
@@ -61,7 +61,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 17426064);
+        cheats.createSelectFork(eth, 17426064);
         cheats.label(address(DAI), "DAI");
         cheats.label(address(cDAI), "cDAI");
         cheats.label(address(yDAI), "yDAI");

--- a/src/test/Conic02_exp.sol
+++ b/src/test/Conic02_exp.sol
@@ -43,7 +43,7 @@ contract ContractTest is Test {
     IBalancerVault Balancer = IBalancerVault(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 17_743_470);
+        vm.createSelectFork(eth, 17_743_470);
         vm.label(address(USDT), "USDT");
         vm.label(address(USDC), "USDC");
         vm.label(address(crvUSD), "crvUSD");

--- a/src/test/Conic_exp.sol
+++ b/src/test/Conic_exp.sol
@@ -63,7 +63,7 @@ contract ContractTest is Test {
     uint256 nonce;
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 17_740_954);
+        vm.createSelectFork(eth, 17_740_954);
         vm.label(address(WETH), "WETH");
         vm.label(address(steCRV), "steCRV");
         vm.label(address(cbETH_ETH_LP), "cbETH_ETH_LP");

--- a/src/test/Conic_exp2.sol
+++ b/src/test/Conic_exp2.sol
@@ -55,7 +55,7 @@ contract ConicFinanceTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 17740954);
+        cheats.createSelectFork(eth, 17740954);
         cheats.label(address(WETH), "WETH");
         cheats.label(address(rETH), "rETH");
         cheats.label(address(stETH), "stETH");

--- a/src/test/Cover_exp.sol
+++ b/src/test/Cover_exp.sol
@@ -24,7 +24,7 @@ contract ContractTest is DSTest {
     IERC20 public Cover = IERC20(0x5D8d9F5b96f4438195BE9b99eee6118Ed4304286);
 
     function setUp() public {
-        cheat.createSelectFork("mainnet", 11_542_309); // fork mainnet at block 11542309
+        cheat.createSelectFork(eth, 11_542_309); // fork mainnet at block 11542309
     }
 
     function test() public {

--- a/src/test/CowSwap_exp.sol
+++ b/src/test/CowSwap_exp.sol
@@ -33,7 +33,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 16_574_048);
+        cheats.createSelectFork(eth, 16_574_048);
         vm.label(address(DAI), "DAI");
         vm.label(address(swapGuard), "SwapGuard");
         vm.label(address(GPv2Settlement), "GPv2Settlement");

--- a/src/test/Cream_2_exp.sol
+++ b/src/test/Cream_2_exp.sol
@@ -163,7 +163,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 13_499_797);
+        cheats.createSelectFork(eth, 13_499_797);
     }
 
     function testExploit() public {

--- a/src/test/Cream_exp.sol
+++ b/src/test/Cream_exp.sol
@@ -42,7 +42,7 @@ contract ContractTest is DSTest {
   CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
   function setUp() public {
-    cheats.createSelectFork("mainnet", 13125070); // fork mainnet at block 13125070
+    cheats.createSelectFork(eth, 13125070); // fork mainnet at block 13125070
   }
 
   function test() public {

--- a/src/test/CurveBurner_exp.sol
+++ b/src/test/CurveBurner_exp.sol
@@ -47,7 +47,7 @@ contract ContractTest is Test {
     IAaveFlashloan aaveV3 = IAaveFlashloan(0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2);
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 17_823_542);
+        vm.createSelectFork(eth, 17_823_542);
         vm.label(address(WETH), "WETH");
         vm.label(address(USDC), "USDC");
         vm.label(address(CurveBurner), "CurveBurner");

--- a/src/test/Curve_exp01.sol
+++ b/src/test/Curve_exp01.sol
@@ -35,7 +35,7 @@ contract ContractTest is Test {
     uint256 nonce;
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 17_806_055);
+        vm.createSelectFork(eth, 17_806_055);
         vm.label(address(WETH), "WETH");
         vm.label(address(pETH), "pETH");
         vm.label(address(CurvePool), "CurvePool");

--- a/src/test/Curve_exp02.sol
+++ b/src/test/Curve_exp02.sol
@@ -47,7 +47,7 @@ contract ContractTest is Test {
     uint256 nonce;
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 17_807_829);
+        vm.createSelectFork(eth, 17_807_829);
         vm.label(address(WETH), "WETH");
         vm.label(address(CRV), "CRV");
         vm.label(address(LP), "LP");

--- a/src/test/DAppSocial_exp.sol
+++ b/src/test/DAppSocial_exp.sol
@@ -41,7 +41,7 @@ contract DAppTest is Test {
     HelperExploitContract private helperExploitContract;
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 18048982);
+        vm.createSelectFork(eth, 18048982);
         vm.label(address(USDT), "USDT");
         vm.label(address(USDC), "USDC");
         vm.label(address(DAppSocial), "DAppSocial");

--- a/src/test/DBW_exp.sol
+++ b/src/test/DBW_exp.sol
@@ -42,7 +42,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 26_745_691);
+        cheats.createSelectFork(bsc, 26_745_691);
         cheats.label(address(USDT), "USDT");
         cheats.label(address(DBW), "DBW");
         cheats.label(address(Pair), "Pair");

--- a/src/test/DDC_exp.sol
+++ b/src/test/DDC_exp.sol
@@ -1,37 +1,11 @@
 pragma solidity ^0.8.10;
 
 import "forge-std/Test.sol";
-//import "./interface.sol";
+import "./interface.sol";
 
-interface CheatCodes {
-    function createSelectFork(string calldata, uint256) external returns (uint256);
-}
-
-interface IERC20 {
-    function balanceOf(address owner) external view returns (uint256);
-    function approve(address spender, uint256 value) external returns (bool);
-    function transfer(address to, uint256 value) external returns (bool);
-}
 
 interface ITokenAFeeHandler is IERC20 {
     function handleDeductFee(uint8 actionType, uint256 feeAmount, address from, address user) external;
-}
-
-interface IRouter {
-    function swapExactTokensForTokens(
-        uint256 amountIn,
-        uint256 amountOutMin,
-        address[] calldata path,
-        address to,
-        uint256 deadline
-    ) external;
-    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
-        uint256 amountIn,
-        uint256 amountOutMin,
-        address[] calldata path,
-        address to,
-        uint256 deadline
-    ) external;
 }
 
 interface IPair {
@@ -47,7 +21,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 20_840_079);
+        cheats.createSelectFork(bsc, 20_840_079);
     }
 
     function testExploit() external {

--- a/src/test/DDCoin_exp.sol
+++ b/src/test/DDCoin_exp.sol
@@ -54,7 +54,7 @@ contract DDTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 28_714_107);
+        cheats.createSelectFork(bsc, 28_714_107);
         cheats.label(address(BUSDT), "BUSDT");
         cheats.label(address(DD), "DD");
         cheats.label(address(DPPOracle1), "DPPOracle1");

--- a/src/test/DEI_exp.sol
+++ b/src/test/DEI_exp.sol
@@ -27,7 +27,7 @@ contract DEIPocTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("https://rpc.ankr.com/arbitrum", 87_626_024);
+        cheats.createSelectFork(arbitrum, 87_626_024);
     }
 
     function testExploit() public {

--- a/src/test/DEPUSDT_LEVUSDC_exp.sol
+++ b/src/test/DEPUSDT_LEVUSDC_exp.sol
@@ -30,7 +30,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 17_484_161);
+        cheats.createSelectFork(eth, 17_484_161);
         cheats.label(address(DEPUSDT), "DEPUSDT");
         cheats.label(address(LEVUSDC), "LEVUSDC");
         cheats.label(address(ProxyDEPUSDT), "ProxyDEPUSDT");

--- a/src/test/DEXRouter_exp.sol
+++ b/src/test/DEXRouter_exp.sol
@@ -34,7 +34,7 @@ contract ContractTest is Test {
         IDEXRouter(0x1f7cF218B46e613D1BA54CaC11dC1b5368d94fb7);
 
     function setUp() public {
-        vm.createSelectFork("bsc", 32161325);
+        vm.createSelectFork(bsc, 32161325);
         vm.label(address(DEXRouter), "DEXRouter");
     }
 

--- a/src/test/DFS_exp.sol
+++ b/src/test/DFS_exp.sol
@@ -33,7 +33,7 @@ contract Attacker is Test {
         cheat.label(usdt, "USDT");
         cheat.label(dfs, "dfs");
         cheat.label(ccds, "ccds");
-        cheat.createSelectFork("bsc", 24_349_821);
+        cheat.createSelectFork(bsc, 24_349_821);
     }
 
     function testExploit() public {

--- a/src/test/DFX_exp.sol
+++ b/src/test/DFX_exp.sol
@@ -30,7 +30,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 15_941_703);
+        cheats.createSelectFork(eth, 15_941_703);
     }
 
     function testExploit() public {

--- a/src/test/DKP_exp.sol
+++ b/src/test/DKP_exp.sol
@@ -28,7 +28,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 26_284_131);
+        cheats.createSelectFork(bsc, 26_284_131);
         cheats.label(address(DKP), "DKP");
         cheats.label(address(USDT), "USDT");
         cheats.label(address(Pair), "Pair");

--- a/src/test/DPC_exp.sol
+++ b/src/test/DPC_exp.sol
@@ -26,7 +26,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 21_179_209);
+        cheats.createSelectFork(bsc, 21_179_209);
     }
 
     function testExploit() external {

--- a/src/test/DYNA_exp.sol
+++ b/src/test/DYNA_exp.sol
@@ -55,7 +55,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 25879486);
+        cheats.createSelectFork(bsc, 25879486);
         cheats.label(address(DYNA), "DYNA");
         cheats.label(address(WBNB), "WBNB");
         cheats.label(address(Router), "Router");

--- a/src/test/DaoMaker_exp.sol
+++ b/src/test/DaoMaker_exp.sol
@@ -25,7 +25,7 @@ contract ContractTest is Test {
     IERC20 DERC = IERC20(0x9fa69536d1cda4A04cFB50688294de75B505a9aE);
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 13_155_320); // fork mainnet block number 13155320
+        vm.createSelectFork(eth, 13_155_320); // fork mainnet block number 13155320
     }
 
     function testExploit() public {

--- a/src/test/DePayRouter_exp.sol
+++ b/src/test/DePayRouter_exp.sol
@@ -54,7 +54,7 @@ contract ContractTest is Test{
     }
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 18281130 - 1);
+        vm.createSelectFork(eth, 18281130 - 1);
         vm.label(address(USDC), "USDC");
         vm.label(address(UNIV2), "UNIV2: USDC");
         vm.label(address(UniRouter), "UniRouter");

--- a/src/test/Defrost_exp.sol
+++ b/src/test/Defrost_exp.sol
@@ -28,7 +28,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("Avalanche", 24_003_940);
+        cheats.createSelectFork(avalanche, 24_003_940);
     }
 
     function testExploit() public {

--- a/src/test/Dexible_exp.sol
+++ b/src/test/Dexible_exp.sol
@@ -46,7 +46,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 16_646_022);
+        cheats.createSelectFork(eth, 16_646_022);
         cheats.label(address(USDC), "USDC");
         cheats.label(address(TRU), "TRU");
         cheats.label(address(Dexible), "Dexible");

--- a/src/test/Discover_exp.sol
+++ b/src/test/Discover_exp.sol
@@ -19,7 +19,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     constructor() {
-        cheats.createSelectFork("bsc", 18_446_845); // fork bsc at block 18446845
+        cheats.createSelectFork(bsc, 18_446_845); // fork bsc at block 18446845
 
         busd.approve(address(ethpledge), type(uint256).max);
         discover.approve(address(ethpledge), type(uint256).max);

--- a/src/test/EAC_exp.sol
+++ b/src/test/EAC_exp.sol
@@ -24,7 +24,7 @@ contract ContractTest is Test {
     address constant private eac = 0x64f291DE10eCd36D5f7b64aaEbC70943CFACE28E;
     
     function setUp() public {
-        vm.createSelectFork("bsc",31273019 - 1);
+        vm.createSelectFork(bsc,31273019 - 1);
         vm.label(usdt, "USDT");
         vm.label(eac, "EAC");
         vm.label(pancakeRouterV2, "PANCAKE_ROUTER_V2");

--- a/src/test/EFLeverVault_exp.sol
+++ b/src/test/EFLeverVault_exp.sol
@@ -24,7 +24,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 15_746_199);
+        cheats.createSelectFork(eth, 15_746_199);
     }
 
     function testExploit() public {

--- a/src/test/EFVault_exp.sol
+++ b/src/test/EFVault_exp.sol
@@ -23,7 +23,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 16_696_239);
+        cheats.createSelectFork(eth, 16_696_239);
     }
 
     function testExploit() external {

--- a/src/test/EGD-Finance.exp.sol
+++ b/src/test/EGD-Finance.exp.sol
@@ -28,7 +28,7 @@ address constant egd = 0x202b233735bF743FA31abb8f71e641970161bF98;
 
 contract Attacker is Test {
     function setUp() public {
-        vm.createSelectFork("bsc", 20_245_522);
+        vm.createSelectFork(bsc, 20_245_522);
 
         vm.label(address(USDT_WBNB_LPPool), "USDT_WBNB_LPPool");
         vm.label(address(EGD_USDT_LPPool), "EGD_USDT_LPPool");

--- a/src/test/EHIVE_exp.sol
+++ b/src/test/EHIVE_exp.sol
@@ -51,7 +51,7 @@ contract EHIVETest is Test {
 
     function setUp() public {
         // Start from the block when exploit contracts were deployed
-        vm.createSelectFork("mainnet", 17690497);
+        vm.createSelectFork(eth, 17690497);
         vm.label(address(WETH), "WETH");
         vm.label(address(EHIVE), "EHIVE");
         vm.label(address(AaveFlashloan), "AaveFlashloan");

--- a/src/test/ERC20TokenBank_exp.sol
+++ b/src/test/ERC20TokenBank_exp.sol
@@ -33,7 +33,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 17376906);
+        cheats.createSelectFork(eth, 17376906);
         cheats.label(address(USDC), "USDC");
         cheats.label(address(USDT), "USDT");
         cheats.label(address(ExchangeBetweenPools), "ExchangeBetweenPools");

--- a/src/test/EarningFram_exp.sol
+++ b/src/test/EarningFram_exp.sol
@@ -37,7 +37,7 @@ contract ContractTest is Test {
     uint256 nonce;
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 17_875_885);
+        vm.createSelectFork(eth, 17_875_885);
         vm.label(address(WETH), "WETH");
         vm.label(address(ENF_ETHLEV), "ENF_ETHLEV");
         vm.label(address(Pair), "Piar");

--- a/src/test/ElasticSwap_exp.sol
+++ b/src/test/ElasticSwap_exp.sol
@@ -52,7 +52,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("Avalanche", 23_563_709);
+        cheats.createSelectFork(avalanche, 23_563_709);
     }
 
     function testExploit() public {

--- a/src/test/Elephant_Money_poc.sol
+++ b/src/test/Elephant_Money_poc.sol
@@ -34,7 +34,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     constructor() {
-        cheats.createSelectFork("bsc", 16_886_438); // fork bsc block number 16886438
+        cheats.createSelectFork(bsc, 16_886_438); // fork bsc block number 16886438
 
         elephant.approve(address(router), type(uint256).max);
 

--- a/src/test/Eleven.sol
+++ b/src/test/Eleven.sol
@@ -38,7 +38,7 @@ contract Eleven is DSTest {
 
     function setUp() public {
         // fork bsc block number 8530973
-        cheats.createSelectFork("bsc", 8_530_973);
+        cheats.createSelectFork(bsc, 8_530_973);
 
         busd.approve(address(router), type(uint256).max);
 

--- a/src/test/Euler_exp.sol
+++ b/src/test/Euler_exp.sol
@@ -73,7 +73,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 16_817_995);
+        cheats.createSelectFork(eth, 16_817_995);
         cheats.label(address(DAI), "DAI");
         cheats.label(address(eDAI), "eDAI");
         cheats.label(address(dDAI), "dDAI");

--- a/src/test/Exactly_exp.sol
+++ b/src/test/Exactly_exp.sol
@@ -117,7 +117,7 @@ contract ContractTest is Test {
     ];
 
     function setUp() public {
-        vm.createSelectFork("optimism", 108_375_557);
+        vm.createSelectFork(optimism, 108_375_557);
         vm.label(address(WETH), "WETH");
         vm.label(address(USDC), "USDC");
         vm.label(address(exaUSDC), "exaUSDC");

--- a/src/test/FAPEN_exp.sol
+++ b/src/test/FAPEN_exp.sol
@@ -26,7 +26,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 28637846);
+        cheats.createSelectFork(bsc, 28637846);
         cheats.label(address(FAPEN), "FAPEN");
         cheats.label(address(WBNB), "WBNB");
         cheats.label(address(Router), "Router");

--- a/src/test/FDP_exp.t.sol
+++ b/src/test/FDP_exp.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.10;
 
 import "forge-std/Test.sol";
+import "./interface.sol";
 
 // Attacker: 0x14d8ada7a0ba91f59dc0cb97c8f44f1d177c2195
 // Attack Contract: 0xdb2d869ac23715af204093e933f5eb57f2dc12a9
@@ -13,7 +14,7 @@ import "forge-std/Test.sol";
 // https://twitter.com/BeosinAlert/status/1622806011269771266
 
 contract Exploit is Test {
-    IWETH private constant WBNB = IWETH(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
+    IWETH private constant WBNB = IWETH(payable(address(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c)));
     reflectiveERC20 private constant FDP = reflectiveERC20(0x1954b6bd198c29c3ecF2D6F6bc70A4D41eA1CC07);
     IUniswapV2Pair private constant FDP_WBNB = IUniswapV2Pair(0x6db8209C3583E7Cecb01d3025c472D1eDDBE49F3);
 
@@ -21,7 +22,7 @@ contract Exploit is Test {
     IDPPOracle private constant DPP = IDPPOracle(0xFeAFe253802b77456B4627F8c2306a9CeBb5d681);
 
     function testHack() external {
-        vm.createSelectFork("https://1rpc.io/bnb", 25_430_418);
+        vm.createSelectFork(bsc, 25_430_418);
 
         // flashloan 16.32 WBNB
         DPP.flashLoan(16.32 ether, 0, address(this), "0x1");
@@ -70,33 +71,4 @@ interface reflectiveERC20 {
     function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
 
     function deliver(uint256 tAmount) external;
-}
-
-interface IWETH {
-    function deposit() external payable;
-    function transfer(address to, uint256 value) external returns (bool);
-    function approve(address guy, uint256 wad) external returns (bool);
-    function withdraw(uint256 wad) external;
-    function balanceOf(address) external view returns (uint256);
-}
-
-interface IDPPOracle {
-    function flashLoan(uint256 baseAmount, uint256 quoteAmount, address sender, bytes calldata data) external;
-}
-
-interface IRouter {
-    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
-        uint256 amountIn,
-        uint256 amountOutMin,
-        address[] calldata path,
-        address to,
-        uint256 deadline
-    ) external;
-}
-
-interface IUniswapV2Pair {
-    function balanceOf(address) external view returns (uint256);
-    function skim(address to) external;
-    function sync() external;
-    function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes memory data) external;
 }

--- a/src/test/FFIST_exp.sol
+++ b/src/test/FFIST_exp.sol
@@ -31,7 +31,7 @@ contract ContractTest is Test {
     Uni_Router_V2 Router = Uni_Router_V2(0x10ED43C718714eb63d5aA57B78B54704E256024E);
 
     function setUp() public {
-        vm.createSelectFork("bsc", 30_113_117);
+        vm.createSelectFork(bsc, 30_113_117);
         vm.label(address(WBNB), "WBNB");
         vm.label(address(FFIST), "FFIST");
         vm.label(address(USDT), "USDT");

--- a/src/test/FPR_exp.sol
+++ b/src/test/FPR_exp.sol
@@ -34,7 +34,7 @@ contract ContractTest is Test {
     
 
     function setUp() public {
-        vm.createSelectFork("bsc", 23904152);
+        vm.createSelectFork(bsc, 23904152);
         vm.label(address(FPR), "FPR token");
         vm.label(address(router), "Router");
         vm.label(address(pair), "Pair");

--- a/src/test/Fantasm_exp.sol
+++ b/src/test/Fantasm_exp.sol
@@ -13,7 +13,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("fantom", 32_971_742); //fork fantom block number 32971742
+        cheats.createSelectFork(fantom, 32_971_742); //fork fantom block number 32971742
     }
 
     function testExploit() public {

--- a/src/test/FireBirdPair_exp.sol
+++ b/src/test/FireBirdPair_exp.sol
@@ -66,7 +66,7 @@ contract ContractTest is Test {
 
 
     function setUp() public {
-        vm.createSelectFork("polygon", 48_149_138 - 1);
+        vm.createSelectFork(polygon, 48_149_138 - 1);
         vm.label(address(Balancer), "Balancer");
         vm.label(address(WMATIC), "WMATIC");
         vm.label(address(USDC), "USDC");

--- a/src/test/FlippazOne.sol
+++ b/src/test/FlippazOne.sol
@@ -10,7 +10,7 @@ contract ContractTest is DSTest {
     Flippaz FlippazOne = Flippaz(0xE85A08Cf316F695eBE7c13736C8Cc38a7Cc3e944);
 
     function setUp() public {
-        cheat.createSelectFork("mainnet", 15_083_765); // fork mainnet at block 15083765
+        cheat.createSelectFork(eth, 15_083_765); // fork mainnet at block 15083765
     }
 
     function testExploit() public {

--- a/src/test/FloorDAO_exp.sol
+++ b/src/test/FloorDAO_exp.sol
@@ -44,7 +44,7 @@ contract FloorStakingExploit is Test {
 
 
     function setUp() public {
-        vm.createSelectFork("https://eth.llamarpc.com", 18068772);
+        vm.createSelectFork(eth, 18068772);
 
         vm.label(address(floor), "floor");
         vm.label(address(sFloor), "sFloor");

--- a/src/test/FortressLoans.exp.sol
+++ b/src/test/FortressLoans.exp.sol
@@ -263,7 +263,7 @@ contract Hacker is DSTest {
     address USDT = 0x55d398326f99059fF775485246999027B3197955;
 
     constructor() {
-        cheat.createSelectFork("bsc", 17_490_837); // Fork BSC mainnet at block 17490837
+        cheat.createSelectFork(bsc, 17_490_837); // Fork BSC mainnet at block 17490837
         emit log_string("This reproduce shows how attacker exploit Fortress Loan, cause ~3,000,000 US$ lost");
         emit log_named_decimal_uint("[Start] Attacker Wallet USDT Balance", IERC20(USDT).balanceOf(address(this)), 18);
         cheat.label(attacker, "AttackerWallet");
@@ -297,7 +297,7 @@ contract Hacker is DSTest {
 
         // txId : 0x12bea43496f35e7d92fb91bf2807b1c95fcc6fedb062d66678c0b5cfe07cc002
         // Do : Create Proposal Id 11
-        cheat.createSelectFork("bsc", 17_490_882);
+        cheat.createSelectFork(bsc, 17_490_882);
         cheat.startPrank(attacker);
         PCreater.ProposalCreated();
         cheat.stopPrank();
@@ -305,7 +305,7 @@ contract Hacker is DSTest {
 
         // txId : 0x83a4f8f52b8f9e6ff1dd76546a772475824d9aa5b953808dbc34d1f39250f29d
         // Do : Vote Proposal Id 11
-        cheat.createSelectFork("bsc", 17_570_125);
+        cheat.createSelectFork(bsc, 17_570_125);
         cheat.startPrank(0x58f96A6D9ECF0a7c3ACaD2f4581f7c4e42074e70); // Malicious voter
         IGovernorAlpha(GovernorAlpha).castVote(11, true);
         cheat.stopPrank();
@@ -313,7 +313,7 @@ contract Hacker is DSTest {
 
         // txId : 0xc368afb2afc499e7ebb575ba3e717497385ef962b1f1922561bcb13f85336252
         // Do : Vote Proposal Id 11
-        cheat.createSelectFork("bsc", 17_570_164);
+        cheat.createSelectFork(bsc, 17_570_164);
         cheat.startPrank(attacker);
         PCreater.castVote();
         cheat.stopPrank();
@@ -321,7 +321,7 @@ contract Hacker is DSTest {
 
         // txId : 0x647c6e89cd1239381dd49a43ca2f29a9fdeb6401d4e268aff1c18b86a7e932a0
         // Do : Queue Proposal Id 11
-        cheat.createSelectFork("bsc", 17_577_532);
+        cheat.createSelectFork(bsc, 17_577_532);
         cheat.startPrank(attacker);
         IGovernorAlpha(GovernorAlpha).queue(11);
         cheat.stopPrank();
@@ -329,7 +329,7 @@ contract Hacker is DSTest {
 
         // txId : 0x4800928c95db2fc877f8ba3e5a41e208231dc97812b0174e75e26cca38af5039
         // Do : Create Attack Contract
-        cheat.createSelectFork("bsc", 17_634_589);
+        cheat.createSelectFork(bsc, 17_634_589);
         cheat.setNonce(attacker, 69);
         cheat.startPrank(attacker);
         Attack attackContract = new Attack();

--- a/src/test/GDS_exp.sol
+++ b/src/test/GDS_exp.sol
@@ -71,7 +71,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 24_449_918);
+        cheats.createSelectFork(bsc, 24_449_918);
         cheats.label(address(GDS), "GDS");
         cheats.label(address(USDT), "USDT");
     }

--- a/src/test/GPT_exp.sol
+++ b/src/test/GPT_exp.sol
@@ -26,7 +26,7 @@ contract CSExp is Test, IDODOCallee {
     IERC20 GPT = IERC20(0xa1679abEF5Cd376cC9A1C4c2868Acf52e08ec1B3);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 28_494_868);
+        cheats.createSelectFork(bsc, 28_494_868);
     }
 
     function doFlashLoan(IDPPOracle oracle) internal {

--- a/src/test/GSS_exp.sol
+++ b/src/test/GSS_exp.sol
@@ -24,7 +24,7 @@ contract ContractTest is Test {
     address constant private dodo_pool = 0x9ad32e3054268B849b84a8dBcC7c8f7c52E4e69A;
 
     function setUp() public {
-        vm.createSelectFork("bsc",31108559 - 1);
+        vm.createSelectFork(bsc,31108559 - 1);
         vm.label(usdt, "USDT");
         vm.label(gss, "GSS");
         vm.label(gss_usdt_pool, "GSS_USDT_POOL");

--- a/src/test/GYMNET_exp.sol
+++ b/src/test/GYMNET_exp.sol
@@ -34,7 +34,7 @@ contract GYMTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 30_448_986);
+        cheats.createSelectFork(bsc, 30_448_986);
         cheats.label(address(GYMNET), "GYMNET");
         cheats.label(address(fakeUSDT), "fakeUSDT");
         cheats.label(address(CakeLP), "CakeLP");

--- a/src/test/Grim_exp.sol
+++ b/src/test/Grim_exp.sol
@@ -24,7 +24,7 @@ contract ContractTest is DSTest {
     uint256 lpBalance;
 
     function setUp() public {
-        cheats.createSelectFork("fantom", 25_345_002); //fork fantom at block 25345002
+        cheats.createSelectFork(fantom, 25_345_002); //fork fantom at block 25345002
     }
 
     function testExploit() public {

--- a/src/test/Gym_1_exp.sol
+++ b/src/test/Gym_1_exp.sol
@@ -22,7 +22,7 @@ contract ContractTest is DSTest {
 
   constructor() {
     cheat.createSelectFork(
-      "bsc",
+      bsc,
       16798806
     ); //fork bsc at block 16798806
 

--- a/src/test/Gym_2_exp.sol
+++ b/src/test/Gym_2_exp.sol
@@ -14,7 +14,7 @@ contract ContractTest is DSTest {
 
   function setUp() public {
     cheat.createSelectFork(
-      "bsc",
+      bsc,
       18501049
     ); //fork bsc at block 18501049
   }

--- a/src/test/HCT_exp.sol
+++ b/src/test/HCT_exp.sol
@@ -43,7 +43,7 @@ contract ContractTest is Test {
     uint baseAMount = 2_200_000_000_000_000_000_000;
 
     function setUp() public {
-        vm.createSelectFork("bsc", 31528198 - 1);
+        vm.createSelectFork(bsc, 31528198 - 1);
         vm.label(address(PancakePair), "PancakePair");
         vm.label(address(router), "PancakeRouter");
         vm.label(address(WBNB), "WBNB");

--- a/src/test/HEALTH_exp.sol
+++ b/src/test/HEALTH_exp.sol
@@ -19,7 +19,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 22_337_425);
+        cheats.createSelectFork(bsc, 22_337_425);
     }
 
     function testExploit() public {

--- a/src/test/HPAY_exp.sol
+++ b/src/test/HPAY_exp.sol
@@ -24,7 +24,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 22_280_853);
+        cheats.createSelectFork(bsc, 22_280_853);
     }
 
     function testExploit() external {

--- a/src/test/HackDao_exp.sol
+++ b/src/test/HackDao_exp.sol
@@ -20,7 +20,7 @@ contract ContractTest is DSTest{
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 18073756);
+        cheats.createSelectFork(bsc, 18073756);
     }
 
     function testExploit() public{

--- a/src/test/Harmony_multisig.sol
+++ b/src/test/Harmony_multisig.sol
@@ -12,7 +12,7 @@ contract ContractTest is DSTest {
     address[] public owner;
 
     function setUp() public {
-        cheat.createSelectFork("mainnet", 15_012_645); //fork mainnet at block 15012645
+        cheat.createSelectFork(eth, 15_012_645); //fork mainnet at block 15012645
     }
 
     function testExploit() public {

--- a/src/test/HarvestFinance_exp.sol
+++ b/src/test/HarvestFinance_exp.sol
@@ -39,7 +39,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 11_129_473); //fork mainnet at block 11129473
+        cheats.createSelectFork(eth, 11_129_473); //fork mainnet at block 11129473
     }
 
     function testExploit() public {

--- a/src/test/HeavensGate_exp.sol
+++ b/src/test/HeavensGate_exp.sol
@@ -41,7 +41,7 @@ contract ContractTest is Test {
     uint amount = 907_615_399_181_304;
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 18069528 - 1);
+        vm.createSelectFork(eth, 18069528 - 1);
         vm.label(address(HATE), "HATE");
         vm.label(address(WETH), "WETH");
         vm.label(address(HATE_ETH_Pair), "Uniswap HATE");

--- a/src/test/HundredFinance_2_exp.sol
+++ b/src/test/HundredFinance_2_exp.sol
@@ -35,7 +35,7 @@ contract contractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("optimism", 90_760_765);
+        cheats.createSelectFork(optimism, 90_760_765);
         cheats.label(address(WBTC), "WBTC");
         cheats.label(address(USDC), "USDC");
         cheats.label(address(SNX), "SNX");

--- a/src/test/HundredFinance_exp.sol
+++ b/src/test/HundredFinance_exp.sol
@@ -54,7 +54,7 @@ contract ContractTest is Test {
     bool xdaiBorrowed = false;
 
     function setUp() public {
-        vm.createSelectFork("gnosis", 21_120_319); //fork gnosis at block number 21120319
+        vm.createSelectFork(gnosis, 21_120_319); //fork gnosis at block number 21120319
     }
 
     function testExploit() public {

--- a/src/test/INUKO_exp.sol
+++ b/src/test/INUKO_exp.sol
@@ -92,7 +92,7 @@ contract ContractTest is DSTest{
 
     function setUp() public {
         // the ankr rpc maybe dont work , please use QuickNode 
-        cheats.createSelectFork("bsc", 22169169);
+        cheats.createSelectFork(bsc, 22169169);
     }
 
     function testExploit() public payable{

--- a/src/test/IndexedFinance_exp.t.sol
+++ b/src/test/IndexedFinance_exp.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.10;
 
 import "forge-std/Test.sol";
+import "./interface.sol";
 
 // @author: https://github.com/Crypto-Virus/indexed-finance-exploit-example/blob/master/contracts/IndexedAttack.sol
 
@@ -58,7 +59,7 @@ contract IndexedAttack is BNum, IUniswapV2Callee, Test {
     uint256 private constant borrowedSushiAmount = 220_000 * 1e18;
 
     function setUp() public {
-        vm.createSelectFork("https://eth.llamarpc.com", 13_417_948);
+        vm.createSelectFork(eth, 13_417_948);
     }
 
     function testHack() public {
@@ -302,12 +303,6 @@ contract IndexedAttack is BNum, IUniswapV2Callee, Test {
 }
 
 /* -------------------- Interface -------------------- */
-interface IERC20 {
-    function transfer(address to, uint256 amount) external returns (bool);
-    function approve(address spender, uint256 amount) external returns (bool);
-    function balanceOf(address account) external view returns (uint256);
-    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
-}
 
 interface IIndexPool {
     function joinswapExternAmountIn(
@@ -338,16 +333,6 @@ interface IIndexPool {
 interface IMarketCapSqrtController {
     function updateMinimumBalance(IIndexPool pool, address tokenAddress) external;
     function reindexPool(address poolAddress) external;
-}
-
-interface IUniswapV2Pair {
-    function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes memory data) external;
-    function token0() external view returns (address);
-    function token1() external view returns (address);
-}
-
-interface IUniswapV2Factory {
-    function getPair(address tokenA, address tokenB) external view returns (address pair);
 }
 
 interface IUniswapV2Router01 {

--- a/src/test/InverseFinance_exp.sol
+++ b/src/test/InverseFinance_exp.sol
@@ -29,7 +29,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 14_972_418); // fork mainnet at block 14972418
+        cheats.createSelectFork(eth, 14_972_418); // fork mainnet at block 14972418
     }
 
     function testExploit() public {

--- a/src/test/JAY_exp.sol
+++ b/src/test/JAY_exp.sol
@@ -31,7 +31,7 @@ contract ContractTest is DSTest{
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 16288199);    // Fork mainnet at block 16288199
+        cheats.createSelectFork(eth, 16288199);    // Fork mainnet at block 16288199
     }
 
     function testExploit() public {

--- a/src/test/Jimbo_exp.sol
+++ b/src/test/Jimbo_exp.sol
@@ -143,7 +143,7 @@ contract JimboExp is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("arbitrum", 95_144_404);
+        cheats.createSelectFork(arbitrum, 95_144_404);
         deal(address(this), 0);
     }
 

--- a/src/test/JumpFarm_exp.sol
+++ b/src/test/JumpFarm_exp.sol
@@ -27,7 +27,7 @@ contract JumpFarmExploit is Test {
     IERC20 sJump = IERC20(0xdd28c9d511a77835505d2fBE0c9779ED39733bdE);
 
     function setUp() public {
-        vm.createSelectFork("https://eth.llamarpc.com", 18070346);
+        vm.createSelectFork(eth, 18070346);
 
         vm.label(address(balancer), "BalancerVault");
         vm.label(address(weth), "WETH");

--- a/src/test/Kashi_exp.sol
+++ b/src/test/Kashi_exp.sol
@@ -62,7 +62,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 15_928_289);
+        cheats.createSelectFork(eth, 15_928_289);
     }
 
     function testExploit() public {

--- a/src/test/Kub_Split_exp.sol
+++ b/src/test/Kub_Split_exp.sol
@@ -72,7 +72,7 @@ contract ContractTest is Test {
         0x7Ccf451D3c48C8bb747f42F29A0CdE4209FF863e;
 
     function setUp() public {
-        vm.createSelectFork("bsc", 32021100 - 1);
+        vm.createSelectFork(bsc, 32021100 - 1);
         vm.label(address(BUSDT_KUB_LP), "BUSDT_KUB_LP");
         vm.label(address(KUB_Split), "KUB_Split");
         vm.label(address(BUSDT), "BUSDT");

--- a/src/test/LFI_exp.sol
+++ b/src/test/LFI_exp.sol
@@ -31,7 +31,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("polygon", 43025776);
+        cheats.createSelectFork(polygon, 43025776);
         cheats.label(address(LFI), "LFI");
         cheats.label(address(VLFI), "VLFI");
     }

--- a/src/test/LPC.exp.sol
+++ b/src/test/LPC.exp.sol
@@ -25,7 +25,7 @@ address constant pancakePair = 0x2ecD8Ce228D534D8740617673F31b7541f6A0099;
 
 contract Exploit is Test {
     function setUp() public {
-        cheat.createSelectFork("bsc", 19852596);
+        cheat.createSelectFork(bsc, 19852596);
         cheat.label(LPC, "LPC");
         cheat.label(pancakePair, "PancakeSwap LPC/USDT");
     }

--- a/src/test/LUSD_exp.sol
+++ b/src/test/LUSD_exp.sol
@@ -44,7 +44,7 @@ contract LUSDTEST is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 29756866);
+        cheats.createSelectFork(bsc, 29756866);
         cheats.label(address(BEP20USDT), "BEP20USDT");
         cheats.label(address(DPPOracle1), "DPPOracle1");
         cheats.label(address(DPPOracle2), "DPPOracle2");

--- a/src/test/LW_exp.sol
+++ b/src/test/LW_exp.sol
@@ -36,7 +36,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 28_133_285);
+        cheats.createSelectFork(bsc, 28_133_285);
         cheats.label(address(USDT), "USDT");
         cheats.label(address(LW), "LW");
         cheats.label(address(LP), "LP");

--- a/src/test/LaunchZone_exp.sol
+++ b/src/test/LaunchZone_exp.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
+import "./interface.sol";
 
 // analysis
 // https://blog.verichains.io/p/analyzing-the-lz-token-hack
@@ -59,7 +60,7 @@ contract LaunchZoneExploit is Test {
 
     function setUp() public {
         // select and fork bsc at 26024420
-        vm.createSelectFork("bsc", 26_024_420 - 1); // previous block so still there is fund
+        vm.createSelectFork(bsc, 26_024_420 - 1); // previous block so still there is fund
         LZ = ERC20Like(0x3B78458981eB7260d1f781cb8be2CaAC7027DbE2);
         BUSD = ERC20Like(0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56);
         BISWAPPair = ERC20Like(0xDb821BB482cfDae5D3B1A48EeaD8d2F74678D593);

--- a/src/test/Leetswap_exp.sol
+++ b/src/test/Leetswap_exp.sol
@@ -32,7 +32,7 @@ contract ContractTest is Test {
     ILeetSwapPiar Pair = ILeetSwapPiar(0x94dAC4a3Ce998143aa119c05460731dA80ad90cf);
 
     function setUp() public {
-        vm.createSelectFork("Base", 2_031_746);
+        vm.createSelectFork(base, 2_031_746);
         vm.label(address(WETH), "WETH");
         vm.label(address(axlUSDC), "axlUSDC");
         vm.label(address(Router), "Router");

--- a/src/test/Level_exp.sol
+++ b/src/test/Level_exp.sol
@@ -53,7 +53,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 27_830_139);
+        cheats.createSelectFork(bsc, 27_830_139);
         cheats.label(address(WBNB), "WBNB");
         cheats.label(address(USDT), "USDT");
         cheats.label(address(LVL), "LVL");

--- a/src/test/Levyathan_poc.sol
+++ b/src/test/Levyathan_poc.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.10;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
+import "./interface.sol";
 
 /*Key Information
 The Levyathan developers left the private keys to a wallet with minting capability available on Github. -rekt
@@ -36,7 +37,7 @@ contract ContractTest is Test {
 
     function setUp() public {
         		
-        vm.createSelectFork("bsc",9545966); //fork bsc at block 9545967
+        vm.createSelectFork(bsc,9545966); //fork bsc at block 9545967
 		
         vm.label(address(MasterChef), "MasterChef");
         vm.label(address(LEV), "LEV");
@@ -127,14 +128,5 @@ function isOperationDone(bytes32 id) external returns (bool done);
 }
 
 interface ILEV {
-function mint(address receiver, uint256 amount) external;
-
-}
-
-interface IMasterChef {
-function recoverLevOwnership() external;
-function leaveStaking(uint256 _amount) external;
-function withdraw(uint256 _pid, uint256 _amount) external;
-function emergencyWithdraw(uint256 _pid) external;
-
+	function mint(address receiver, uint256 amount) external;
 }

--- a/src/test/LiFi_exp.sol
+++ b/src/test/LiFi_exp.sol
@@ -48,7 +48,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 14_420_686); //fork mainnet at block 14420686
+        cheats.createSelectFork(eth, 14_420_686); //fork mainnet at block 14420686
     }
 
     function testExploit() public {

--- a/src/test/Libertify_exp.sol
+++ b/src/test/Libertify_exp.sol
@@ -58,7 +58,7 @@ contract ContractTest is Test {
     uint256 nonce;
 
     function setUp() public {
-        vm.createSelectFork("polygon", 44_941_584);
+        vm.createSelectFork(polygon, 44_941_584);
         vm.label(address(USDT), "USDT");
         vm.label(address(WETH), "WETH");
         vm.label(address(aaveV2), "aaveV2");

--- a/src/test/LocalTrader2_exp.sol
+++ b/src/test/LocalTrader2_exp.sol
@@ -27,7 +27,7 @@ contract LocalTraders is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 28_460_897);
+        cheats.createSelectFork(bsc, 28_460_897);
         cheats.label(address(LCTExchange), "LCTExchange");
         cheats.label(address(Router), "Router");
         cheats.label(address(LCT), "LCT");

--- a/src/test/LocalTrader_exp.sol
+++ b/src/test/LocalTrader_exp.sol
@@ -27,7 +27,7 @@ contract LCTExp is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 28_460_897);
+        cheats.createSelectFork(bsc, 28_460_897);
         deal(address(this), 1 ether);
     }
 

--- a/src/test/Lodestar_exp.sol
+++ b/src/test/Lodestar_exp.sol
@@ -77,7 +77,7 @@ contract ContractTest is Test{
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("arbitrum", 45121903);
+        cheats.createSelectFork(arbitrum, 45121903);
         cheats.label(address(USDC), "USDC");
         cheats.label(address(DAI), "DAI");
         cheats.label(address(WETH), "WETH");

--- a/src/test/LuckyTiger_exp.sol
+++ b/src/test/LuckyTiger_exp.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.13;
 
-
 import "forge-std/Test.sol";
+import "./interface.sol";
 
 /*
     Attacker: 0x3392c91403f09ad3b7e7243dbd4441436c7f443c
@@ -23,7 +23,7 @@ contract luckyHack is Test {
    address nftAddress = 0x9c87A5726e98F2f404cdd8ac8968E9b2C80C0967;   
    
     function setUp() public {
-        vm.createSelectFork("mainnet", 15403430); // fork mainnet block number 15403430
+        vm.createSelectFork(eth, 15403430); // fork mainnet block number 15403430
         vm.deal(address(this), 3 ether);
         vm.deal(address(nftAddress), 5 ether);
     }

--- a/src/test/MBC_ZZSH_exp.sol
+++ b/src/test/MBC_ZZSH_exp.sol
@@ -34,7 +34,7 @@ contract ContractTest is DSTest {
     uint256 dodoFlahloanAmount;
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 23_474_460);
+        cheats.createSelectFork(bsc, 23_474_460);
     }
 
     function testExploit() public {

--- a/src/test/MEV_0ad8.t.sol
+++ b/src/test/MEV_0ad8.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.10;
 
 import "forge-std/Test.sol";
+import "./interface.sol";
 
 // Attacker: 0xae39a6c2379bef53334ea968f4c711c8cf3898b6
 // Vulnerable Contract: 0x0ad8229d4bc84135786ae752b9a9d53392a8afd4
@@ -20,7 +21,7 @@ contract Exploit is Test {
     address private constant victim = 0x211B6a1137BF539B2750e02b9E525CF5757A35aE;
 
     function testHack() external {
-        vm.createSelectFork("https://rpc.builder0x69.io", 15_926_096);
+        vm.createSelectFork(eth, 15_926_096);
 
         // use these tools to decode raw calldata: https://www.ethcmd.com/tools/decode-calldata/  +  https://calldata-decoder.apoorv.xyz/
         bytes memory payload = abi.encodeWithSelector(
@@ -36,22 +37,4 @@ contract Exploit is Test {
 
         console.log("Attacker's profit: %s USDC", USDC.balanceOf(attacker) / 1e6);
     }
-}
-
-/* -------------------- Interface -------------------- */
-interface IERC20 {
-    function transfer(address to, uint256 amount) external returns (bool);
-    function approve(address spender, uint256 amount) external returns (bool);
-    function balanceOf(address account) external view returns (uint256);
-    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
-
-    function deliver(uint256 tAmount) external;
-}
-
-interface WETH9 {
-    function deposit() external payable;
-    function transfer(address to, uint256 value) external returns (bool);
-    function approve(address guy, uint256 wad) external returns (bool);
-    function withdraw(uint256 wad) external;
-    function balanceOf(address) external view returns (uint256);
 }

--- a/src/test/MEVa47b_exp.sol
+++ b/src/test/MEVa47b_exp.sol
@@ -18,7 +18,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 15_741_332);
+        cheats.createSelectFork(eth, 15_741_332);
     }
 
     function testExploit() public {

--- a/src/test/MEVbadc0de_exp.sol
+++ b/src/test/MEVbadc0de_exp.sol
@@ -89,7 +89,7 @@ contract ContractTest is Test {
         exploiter = cheats.addr(31_337);
 
         // fork mainnet at block 15625424
-        cheats.createSelectFork("mainnet", 15_625_424);
+        cheats.createSelectFork(eth, 15_625_424);
     }
 
     function testExploit() public {

--- a/src/test/MIMSpell_exp.sol
+++ b/src/test/MIMSpell_exp.sol
@@ -60,7 +60,7 @@ contract MIMTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 17_521_638);
+        cheats.createSelectFork(eth, 17_521_638);
         deal(address(SUSDT), exploiter, 3e6);
         cheats.startPrank(exploiter);
         SUSDT.approve(address(this), type(uint256).max);

--- a/src/test/MUMUG_exp.sol
+++ b/src/test/MUMUG_exp.sol
@@ -26,7 +26,7 @@ contract ContractTest is DSTest{
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("Avalanche", 23435294);
+        cheats.createSelectFork(avalanche, 23435294);
     }
 
     function testExploit() public{

--- a/src/test/Market_exp.t.sol
+++ b/src/test/Market_exp.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.17;
 
 import "forge-std/Test.sol";
+import "./interface.sol";
 
 // Total Lost: $180k
 // Attacker: 0x4206d62305d2815494dcdb759c4e32fca1d181a0
@@ -54,7 +55,7 @@ contract MarketExploitTest is Test {
 
     IUnitroller private constant unitroller = IUnitroller(0x627742AaFe82EB5129DD33D237FF318eF5F76CBC);
     IRouter private constant router = IRouter(0xa5E0829CaCEd8fFDD4De3c43696c57F7D7A678ff);
-    Uni_Router_V3 private constant routerV3 = Uni_Router_V3(0xf5b509bB0909a69B1c207E495f687a596C168E12);
+    UniRouter_V3 private constant routerV3 = UniRouter_V3(0xf5b509bB0909a69B1c207E495f687a596C168E12);
 
     CErc20Interface private constant CErc20_mmooCurvestMATIC_MATIC_4 =
         CErc20Interface(0x570Bc2b7Ad1399237185A27e66AEA9CfFF5F3dB8);
@@ -64,7 +65,7 @@ contract MarketExploitTest is Test {
     IERC20 private constant USDC = IERC20(0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174);
 
     function setUp() public {
-        vm.createSelectFork("https://polygon.llamarpc.com", 34_716_800); // fork Polygon at block 34716800
+        vm.createSelectFork(polygon, 34_716_800); // fork Polygon at block 34716800
         vm.deal(address(this), 0); // set address(this).balance to 0
     }
 
@@ -188,7 +189,7 @@ contract MarketExploitTest is Test {
 
         // swap some WMATIC for stMATIC to repay Balancer
         WMATIC.approve(address(routerV3), type(uint256).max);
-        Uni_Router_V3.ExactInputSingleParams memory _Params = Uni_Router_V3.ExactInputSingleParams({
+        UniRouter_V3.ExactInputSingleParams memory _Params = UniRouter_V3.ExactInputSingleParams({
             tokenIn: address(WMATIC),
             tokenOut: address(stMATIC),
             deadline: type(uint256).max,
@@ -202,24 +203,6 @@ contract MarketExploitTest is Test {
 }
 
 /* -------------------- Interface -------------------- */
-interface CErc20Interface {
-    function mint(uint256 mintAmount) external returns (uint256);
-    function balanceOf(address account) external view returns (uint256);
-    function borrow(uint256 borrowAmount) external returns (uint256);
-    function redeem(uint256 amount) external;
-    function withdrawAll() external;
-    function transfer(address to, uint256 amount) external returns (bool);
-}
-
-interface ICErc20Delegate {
-    function liquidateBorrow(
-        address borrower,
-        uint256 repayAmount,
-        address cTokenCollateral
-    ) external returns (uint256);
-    function borrow(uint256 borrowAmount) external returns (uint256);
-}
-
 interface BeefyVault {
     function deposit(uint256 _amount) external;
     function withdraw(uint256 _amount) external;
@@ -231,65 +214,7 @@ interface BeefyVault {
     function transfer(address recipient, uint256 amount) external returns (bool);
 }
 
-interface IUnitroller {
-    function enterMarkets(address[] memory cTokens) external returns (uint256[] memory);
-    function exitMarket(address cTokenAddress) external returns (uint256);
-    function cTokensByUnderlying(address) external view returns (address);
-    function getAccountLiquidity(address account) external view returns (uint256, uint256, uint256);
-}
-
-interface IERC20 {
-    function transfer(address to, uint256 amount) external returns (bool);
-    function approve(address spender, uint256 amount) external returns (bool);
-    function balanceOf(address account) external view returns (uint256);
-    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
-}
-
-interface WETH9 {
-    function deposit() external payable;
-    function transfer(address to, uint256 value) external returns (bool);
-    function approve(address guy, uint256 wad) external returns (bool);
-    function withdraw(uint256 wad) external;
-    function balanceOf(address) external view returns (uint256);
-}
-
-interface ILendingPool {
-    function flashLoan(
-        address receiverAddress,
-        address[] calldata assets,
-        uint256[] calldata amounts,
-        uint256[] calldata modes,
-        address onBehalfOf,
-        bytes calldata params,
-        uint16 referralCode
-    ) external;
-}
-
-interface IBalancerVault {
-    function flashLoan(
-        address recipient,
-        address[] memory tokens,
-        uint256[] memory amounts,
-        bytes memory userData
-    ) external;
-}
-
-interface ICurvePool {
-    function remove_liquidity(uint256 _amount, uint256[2] calldata min_amounts, bool donate_dust) external;
-    function add_liquidity(uint256[2] memory amounts, uint256 min_mint_amount) external returns (uint256);
-}
-
-interface IRouter {
-    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
-        uint256 amountIn,
-        uint256 amountOutMin,
-        address[] calldata path,
-        address to,
-        uint256 deadline
-    ) external;
-}
-
-interface Uni_Router_V3 {
+interface UniRouter_V3 {
     struct ExactInputSingleParams {
         address tokenIn;
         address tokenOut;

--- a/src/test/Melo_exp.sol
+++ b/src/test/Melo_exp.sol
@@ -24,7 +24,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 27_960_445);
+        cheats.createSelectFork(bsc, 27_960_445);
     }
 
     function testExploit() external {

--- a/src/test/MetaPoint_exp.sol
+++ b/src/test/MetaPoint_exp.sol
@@ -26,7 +26,7 @@ contract ContractTest is Test {
     Uni_Router_V2 Router = Uni_Router_V2(0x10ED43C718714eb63d5aA57B78B54704E256024E);
 
     function setUp() public {
-        vm.createSelectFork("bsc", 27_264_384 - 1);
+        vm.createSelectFork(bsc, 27_264_384 - 1);
     }
 
     function testExploit() public {

--- a/src/test/Meter_exp.sol
+++ b/src/test/Meter_exp.sol
@@ -22,7 +22,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("moonriver", 1_442_490); //fork moonriver at block 1442490
+        cheats.createSelectFork(moonriver, 1_442_490); //fork moonriver at block 1442490
             // https://moonriver.moonscan.io/tx/0x5a87c24d0665c8f67958099d1ad22e39a03aa08d47d00b7276b8d42294ee0591
     }
 

--- a/src/test/Midas_exp.sol
+++ b/src/test/Midas_exp.sol
@@ -71,7 +71,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("https://polygon.llamarpc.com", 38_118_347);
+        cheats.createSelectFork(polygon, 38_118_347);
         cheats.label(address(balancer), "balancer");
         cheats.label(address(aaveV3), "aaveV3");
         cheats.label(address(aaveV2), "aaveV2");

--- a/src/test/MintoFinance_exp.sol
+++ b/src/test/MintoFinance_exp.sol
@@ -55,7 +55,7 @@ contract MintoFinance_exp is Test {
     IERC20 BTCMT;
 
     function setUp() public {
-        vm.createSelectFork("bsc", 30_214_253);
+        vm.createSelectFork(bsc, 30_214_253);
         BTCMT = IERC20(0x410a56541bD912F9B60943fcB344f1E3D6F09567);
     }
 

--- a/src/test/Mono_exp.t.sol
+++ b/src/test/Mono_exp.t.sol
@@ -27,7 +27,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 13_715_025); //fork mainnet at block 13715025
+        cheats.createSelectFork(eth, 13_715_025); //fork mainnet at block 13715025
     }
 
     function testExploit() public {

--- a/src/test/MooCAKECTX_exp.sol
+++ b/src/test/MooCAKECTX_exp.sol
@@ -58,7 +58,7 @@ contract ContractTest is DSTest {
 
     function setUp() public {
         // the ankr rpc maybe dont work , please use QuickNode
-        cheats.createSelectFork("bsc", 22_832_427);
+        cheats.createSelectFork(bsc, 22_832_427);
     }
 
     function testExploit() public {

--- a/src/test/MulticallWithoutCheck_exp.sol
+++ b/src/test/MulticallWithoutCheck_exp.sol
@@ -27,7 +27,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("polygon", 34_743_770);
+        cheats.createSelectFork(polygon, 34_743_770);
     }
 
     function testExploit() public {

--- a/src/test/N00d_exp.sol
+++ b/src/test/N00d_exp.sol
@@ -30,7 +30,7 @@ contract ContractTest is DSTest{
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 15826379);
+        cheats.createSelectFork(eth, 15826379);
     }
 
     function testExploit() public{

--- a/src/test/NOON_exp.sol
+++ b/src/test/NOON_exp.sol
@@ -31,7 +31,7 @@ contract ContractTest is Test {
     address public constant flashbotsBuilder = 0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5;
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 17_366_979);
+        cheats.createSelectFork(eth, 17_366_979);
         cheats.label(address(NO), "NO");
         cheats.label(address(WETH), "WETH");
         cheats.label(address(Pair), "Pair");

--- a/src/test/NST_exp.sol
+++ b/src/test/NST_exp.sol
@@ -34,7 +34,7 @@ contract NstExploitTest is Test {
     address swapper = 0x9D101E71064971165Cd801E39c6B07234B65aa88;
 
     function setUp() public {
-        cheats.createSelectFork("polygon", 43_430_814);
+        cheats.createSelectFork(polygon, 43_430_814);
         vm.label(address(usdt), "USDT");
         vm.label(address(nst), "NST");
         vm.label(swapper, "swapper");

--- a/src/test/NUM_exp.sol
+++ b/src/test/NUM_exp.sol
@@ -35,7 +35,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 16_029_969);
+        cheats.createSelectFork(eth, 16_029_969);
     }
 
     function testExploit() external {

--- a/src/test/NXUSD_exp.sol
+++ b/src/test/NXUSD_exp.sol
@@ -59,7 +59,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("Avalanche", 19_613_451);
+        cheats.createSelectFork(avalanche, 19_613_451);
     }
 
     function testExploit() public {

--- a/src/test/NerveBridge.t.sol
+++ b/src/test/NerveBridge.t.sol
@@ -45,7 +45,7 @@ contract ContractTest is Test {
     address nerve3pool = 0x1B3771a66ee31180906972580adE9b81AFc5fCDc;
 
     function setUp() public {
-        mainnetFork = vm.createFork("bsc", 12_653_565);
+        mainnetFork = vm.createFork(bsc, 12_653_565);
         vm.selectFork(mainnetFork);
         cheats.label(address(flashloanProvider), "flashloanProvider");
     }

--- a/src/test/NeutraFinance_exp.sol
+++ b/src/test/NeutraFinance_exp.sol
@@ -327,7 +327,7 @@ contract CounterTest is Test {
         ICamelotPair(0x2ea3CA79413C2EC4C1893D5f8C34C16acB2288A4);
 
     function setUp() public {
-        vm.createSelectFork("arbitrum", 117189138);
+        vm.createSelectFork(arbitrum, 117189138);
         vm.label(address(WETH), "WETH");
         vm.label(address(NEU), "NEU");
     }

--- a/src/test/NeverFall_exp.sol
+++ b/src/test/NeverFall_exp.sol
@@ -24,7 +24,7 @@ contract ContractTest is Test {
     address payable pancakeRouter = payable(0x10ED43C718714eb63d5aA57B78B54704E256024E);
 
     function setUp() public {
-        vm.createSelectFork("bsc", 27_863_178 - 1);
+        vm.createSelectFork(bsc, 27_863_178 - 1);
     }
 
     function testExploit() public {

--- a/src/test/NewFi_exp.sol
+++ b/src/test/NewFi_exp.sol
@@ -39,7 +39,7 @@ contract ContractTest is Test {
     IStakedV3 StakedV3 = IStakedV3(0xB8dC09Eec82CaB2E86C7EdC8DD5882dd92d22411);
 
     function setUp() public {
-        vm.createSelectFork("bsc", 30_043_573);
+        vm.createSelectFork(bsc, 30_043_573);
         vm.label(address(BUSD), "BUSD");
         vm.label(address(USDT), "USDT");
         vm.label(address(Router), "Router");

--- a/src/test/NewFreeDAO_exp.sol
+++ b/src/test/NewFreeDAO_exp.sol
@@ -34,7 +34,7 @@ contract Attacker is Test {
     address constant nfd = 0x38C63A5D3f206314107A7a9FE8cBBa29D629D4F9;
 
     function setUp() public {
-        cheat.createSelectFork("bsc", 21_140_434);
+        cheat.createSelectFork(bsc, 21_140_434);
         console.log("---------- Reproduce Attack Tx1 ----------");
         cheat.label(address(PancakeRouter), "PancakeRouter");
         cheat.label(vulnContract, "vulnContractName");

--- a/src/test/Nimbus_exp.sol
+++ b/src/test/Nimbus_exp.sol
@@ -22,7 +22,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 13_225_516); //fork bsc at block 13225516
+        cheats.createSelectFork(eth, 13_225_516); //fork bsc at block 13225516
     }
 
     function testExploit() public {

--- a/src/test/Nmbplatform_exp.sol
+++ b/src/test/Nmbplatform_exp.sol
@@ -48,7 +48,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 23_639_507);
+        cheats.createSelectFork(bsc, 23_639_507);
     }
 
     function testExploit() public {

--- a/src/test/NomadBridge.exp.sol
+++ b/src/test/NomadBridge.exp.sol
@@ -34,7 +34,7 @@ IERC20 constant WBTC = IERC20(0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599);
 
 contract Attacker is Test {
     function setUp() public {
-        cheat.createSelectFork("mainnet", 15_259_100);
+        cheat.createSelectFork(eth, 15_259_100);
         cheat.label(address(Replica), "Replica");
         cheat.label(address(WBTC), "WBTC");
     }

--- a/src/test/NovaExchange_exp.sol
+++ b/src/test/NovaExchange_exp.sol
@@ -27,7 +27,7 @@ contract ContractTest is DSTest {
     IPancakeRouter wbnb_nova = IPancakeRouter(payable(0x10ED43C718714eb63d5aA57B78B54704E256024E)); // wbnb/nova Pair
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 23_749_678); //fork bsc at block number 23749678
+        cheats.createSelectFork(bsc, 23_749_678); //fork bsc at block number 23749678
 
         //novaContract.approve(address(wbnb_nova), type(uint256).max);
         //WBNB.approve(address(wbnb_nova), type(uint256).max);

--- a/src/test/Novo_exp.sol
+++ b/src/test/Novo_exp.sol
@@ -26,7 +26,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 18_225_002); //fork bsc at block number 18225002
+        cheats.createSelectFork(bsc, 18_225_002); //fork bsc at block number 18225002
     }
 
     function testExploit() public {

--- a/src/test/NowSwap_exp.sol
+++ b/src/test/NowSwap_exp.sol
@@ -18,7 +18,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 13_225_516); //fork bsc at block 13225516
+        cheats.createSelectFork(eth, 13_225_516); //fork bsc at block 13225516
     }
 
     function testExploit() public {

--- a/src/test/OLIFE_exp.sol
+++ b/src/test/OLIFE_exp.sol
@@ -33,7 +33,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() external {
-        cheats.createSelectFork("bsc", 27_470_678);
+        cheats.createSelectFork(bsc, 27_470_678);
     }
 
     function testExploit() external {

--- a/src/test/OlympusDao.exp.sol
+++ b/src/test/OlympusDao.exp.sol
@@ -36,7 +36,7 @@ contract FakeToken {
 
 contract AttackContract is Test {
     function setUp() public {
-        cheat.createSelectFork("mainnet", 15_794_363);
+        cheat.createSelectFork(eth, 15_794_363);
         cheat.label(OHM, "OHM");
         cheat.label(BondFixedExpiryTeller, "BondFixedExpiryTeller");
     }

--- a/src/test/OmniEstate_exp.sol
+++ b/src/test/OmniEstate_exp.sol
@@ -25,7 +25,7 @@ contract ContractTest is Test {
     IWBNB WBNB = IWBNB(payable(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c));
 
     function setUp() public {
-        vm.createSelectFork("bsc", 24_850_696);
+        vm.createSelectFork(bsc, 24_850_696);
     }
 
     function testExploit() public {

--- a/src/test/Omni_exp.sol
+++ b/src/test/Omni_exp.sol
@@ -27,7 +27,7 @@ contract ContractTest is DSTest {
     }
 
     constructor() {
-        cheats.createSelectFork("mainnet", 15_114_361); // fork mainnet at block 15114361
+        cheats.createSelectFork(eth, 15_114_361); // fork mainnet at block 15114361
         owner = msg.sender; // Hacker
     }
 

--- a/src/test/OneRing_exp.sol
+++ b/src/test/OneRing_exp.sol
@@ -11,7 +11,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("fantom", 34_041_499); //fork fantom at block 34041499
+        cheats.createSelectFork(fantom, 34_041_499); //fork fantom at block 34041499
     }
 
     function testExploit() public {

--- a/src/test/Optimism_exp.sol
+++ b/src/test/Optimism_exp.sol
@@ -14,7 +14,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("optimism", 10_607_735); //fork optimism at block 10607735
+        cheats.createSelectFork(optimism, 10_607_735); //fork optimism at block 10607735
     }
 
     function testExploit() public {

--- a/src/test/Opyn.exp.sol
+++ b/src/test/Opyn.exp.sol
@@ -21,7 +21,7 @@ contract ContractTest is DSTest {
     IUSDC usdc = IUSDC(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 10_592_516); //fork mainnet at block 10592516
+        cheats.createSelectFork(eth, 10_592_516); //fork mainnet at block 10592516
     }
 
     function test_attack() public {

--- a/src/test/Orion_exp.sol
+++ b/src/test/Orion_exp.sol
@@ -47,7 +47,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 16_542_147);
+        cheats.createSelectFork(eth, 16_542_147);
         vm.label(address(USDT), "USDT");
         vm.label(address(USDC), "USDC");
         vm.label(address(Orion), "ORION");

--- a/src/test/Overnight_exp.sol
+++ b/src/test/Overnight_exp.sol
@@ -134,7 +134,7 @@ contract ContractTest is DSTest{
 
 
     function setUp() public {
-        cheats.createSelectFork("Avalanche", 23097846); 
+        cheats.createSelectFork(avalanche, 23097846); 
     }
 
     function testExploit() public payable{

--- a/src/test/PAID_exp.sol
+++ b/src/test/PAID_exp.sol
@@ -22,7 +22,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 11_979_839); // Fork mainnet at block 11979839
+        cheats.createSelectFork(eth, 11_979_839); // Fork mainnet at block 11979839
     }
 
     function testExploit() public {

--- a/src/test/PLTD_exp.sol
+++ b/src/test/PLTD_exp.sol
@@ -19,7 +19,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 22_252_045);
+        cheats.createSelectFork(bsc, 22_252_045);
     }
 
     function testExploit() external {

--- a/src/test/Palmswap_exp.sol
+++ b/src/test/Palmswap_exp.sol
@@ -38,7 +38,7 @@ contract PalmswapTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 30_248_637);
+        cheats.createSelectFork(bsc, 30_248_637);
         cheats.label(address(BUSDT), "BUSDT");
         cheats.label(address(PLP), "PLP");
         cheats.label(address(USDP), "USDP");

--- a/src/test/PancakeBunny_exp.sol
+++ b/src/test/PancakeBunny_exp.sol
@@ -73,7 +73,7 @@ contract ContractTest is DSTest {
     address keeper = 0x793074D9799DC3c6039F8056F1Ba884a73462051;
 
     constructor() public {
-        cheat.createSelectFork("bsc", 7556330);
+        cheat.createSelectFork(bsc, 7556330);
 
         IERC20(WBNB).approve(address(zap), 1e18);
         IERC20(address(WBNBUSDTv2)).approve(address(flip), type(uint256).max);

--- a/src/test/PancakeHunny_exp.sol
+++ b/src/test/PancakeHunny_exp.sol
@@ -34,7 +34,7 @@ contract ContractTest is DSTest {
     IERC20 hunny = IERC20(0x565b72163f17849832A692A3c5928cc502f46D69);
 
     constructor() {
-        cheat.createSelectFork("bsc", 7_962_338); //fork bsc at block 7962338
+        cheat.createSelectFork(bsc, 7_962_338); //fork bsc at block 7962338
 
         wbnb.approve(address(pancakeRouter), type(uint256).max);
         hunny.approve(address(pancakeRouter), type(uint256).max);

--- a/src/test/Paraluni_exp.sol
+++ b/src/test/Paraluni_exp.sol
@@ -51,7 +51,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 16_008_280); //fork bsc at block 16008280
+        cheats.createSelectFork(bsc, 16_008_280); //fork bsc at block 16008280
     }
 
     function testExploit() public {

--- a/src/test/Paraspace_exp_2.sol
+++ b/src/test/Paraspace_exp_2.sol
@@ -38,7 +38,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 16_845_558);
+        cheats.createSelectFork(eth, 16_845_558);
         vm.label(address(wstETH), "wstETH");
         vm.label(address(USDC), "USDC");
         vm.label(address(cAPE), "cAPE");

--- a/src/test/Paribus_exp.sol
+++ b/src/test/Paribus_exp.sol
@@ -33,7 +33,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("arbitrum", 79_308_097);
+        cheats.createSelectFork(arbitrum, 79_308_097);
         cheats.label(address(WBTC), "WBTC");
         cheats.label(address(USDT), "USDT");
         cheats.label(address(WETH), "WETH");

--- a/src/test/Parity_kill.sol
+++ b/src/test/Parity_kill.sol
@@ -19,7 +19,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 4_501_735); //fork mainnet at block 4501735
+        cheats.createSelectFork(eth, 4_501_735); //fork mainnet at block 4501735
     }
 
     function testExploit() public {

--- a/src/test/Pawnfi_exp.sol
+++ b/src/test/Pawnfi_exp.sol
@@ -135,7 +135,7 @@ contract PawnfiTest is Test {
         IApeStaking(0x5954aB967Bc958940b7EB73ee84797Dc8a2AFbb9);
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 17496619);
+        vm.createSelectFork(eth, 17496619);
         vm.label(address(UniV3Pool), "UniV3Pool");
         vm.label(address(APE), "APE");
         vm.label(address(sAPE), "sAPE");

--- a/src/test/Phoenix_exp.sol
+++ b/src/test/Phoenix_exp.sol
@@ -29,7 +29,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("polygon", 40_066_946);
+        cheats.createSelectFork(polygon, 40_066_946);
         vm.label(address(USDC), "USDC");
         vm.label(address(WETH), "WETH");
         vm.label(address(phxProxy), "phxProxy");

--- a/src/test/Pickle_exp.sol
+++ b/src/test/Pickle_exp.sol
@@ -26,7 +26,7 @@ contract AttackContract is Test {
     address constant weth = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
     function setUp() public {
-        cheat.createSelectFork("mainnet", 11303122);    // Fork mainnet at block 11303122
+        cheat.createSelectFork(eth, 11303122);    // Fork mainnet at block 11303122
     }
 
     function testExploit() public {

--- a/src/test/Platypus02_exp.sol
+++ b/src/test/Platypus02_exp.sol
@@ -52,7 +52,7 @@ contract ContractTest is Test {
     IAaveFlashloan aaveV3 = IAaveFlashloan(0x794a61358D6845594F94dc1DB02A252b5b4814aD);
 
     function setUp() public {
-        vm.createSelectFork("Avalanche", 32_470_736);
+        vm.createSelectFork(avalanche, 32_470_736);
         vm.label(address(USDTe), "USDTe");
         vm.label(address(USDC), "USDC");
         vm.label(address(LP_USDC), "LP_USDC");

--- a/src/test/Platypus03_exp.sol
+++ b/src/test/Platypus03_exp.sol
@@ -49,7 +49,7 @@ contract ContractTest is Test {
     IAaveFlashloan aaveV3 = IAaveFlashloan(0x794a61358D6845594F94dc1DB02A252b5b4814aD);
 
     function setUp() public {
-        vm.createSelectFork("Avalanche", 36_346_397);
+        vm.createSelectFork(avalanche, 36_346_397);
         vm.label(address(WAVAX), "WAVAX");
         vm.label(address(SAVAX), "SAVAX");
         vm.label(address(LP_AVAX), "LP_AVAX");

--- a/src/test/Platypus_exp.sol
+++ b/src/test/Platypus_exp.sol
@@ -61,7 +61,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("Avalanche", 26_343_613);
+        cheats.createSelectFork(avalanche, 26_343_613);
         cheats.label(address(USDC), "USDC");
         cheats.label(address(USP), "USP");
         cheats.label(address(USDC_E), "USDC_E");

--- a/src/test/PolyNetwork/PolyNetwork_exp.sol
+++ b/src/test/PolyNetwork/PolyNetwork_exp.sol
@@ -72,7 +72,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 12_996_658); //fork mainnet at block 12996658
+        cheats.createSelectFork(eth, 12_996_658); //fork mainnet at block 12996658
     }
 
     function testExploit() public {

--- a/src/test/QTN_exp.sol
+++ b/src/test/QTN_exp.sol
@@ -28,7 +28,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 16_430_212);
+        cheats.createSelectFork(eth, 16_430_212);
         cheats.label(address(QTN), "QTN");
         cheats.label(address(WETH), "WETH");
         cheats.label(address(Router), "Router");

--- a/src/test/Qubit_exp.sol
+++ b/src/test/Qubit_exp.sol
@@ -24,7 +24,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 14_090_169); //fork mainnet at block 14090169
+        cheats.createSelectFork(eth, 14_090_169); //fork mainnet at block 14090169
     }
 
     function testExploit() public {
@@ -52,7 +52,7 @@ contract ContractTest is DSTest {
 
         IQBridge(QBridge).deposit(1, resourceID, data);
 
-        // cheats.createSelectFork("bsc", 14742311); //fork mainnet at block 14742311
+        // cheats.createSelectFork(bsc, 14742311); //fork mainnet at block 14742311
     }
 
     receive() external payable {}

--- a/src/test/Quixotic_exp.sol
+++ b/src/test/Quixotic_exp.sol
@@ -27,7 +27,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("optimism", 13_591_383); //fork optimism at block 13591383
+        cheats.createSelectFork(optimism, 13_591_383); //fork optimism at block 13591383
     }
 
     function testExploit() public {

--- a/src/test/RADT_exp.sol
+++ b/src/test/RADT_exp.sol
@@ -23,7 +23,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 21_572_418);
+        cheats.createSelectFork(bsc, 21_572_418);
     }
 
     function testExploit() public {

--- a/src/test/RES02_exp.sol
+++ b/src/test/RES02_exp.sol
@@ -39,7 +39,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 21_948_016);
+        cheats.createSelectFork(bsc, 21_948_016);
     }
 
     function testExploit() public payable {

--- a/src/test/RES_exp.sol
+++ b/src/test/RES_exp.sol
@@ -27,7 +27,7 @@ contract Attacker is Test {
     RES constant restoken = RES(0xecCD8B08Ac3B587B7175D40Fb9C60a20990F8D21);
 
     function setUp() public {
-        cheat.createSelectFork("bsc", 21_948_016);
+        cheat.createSelectFork(bsc, 21_948_016);
     }
 
     function stringsEquals(bytes calldata s1, string memory s2) private returns (bool) {

--- a/src/test/RFB_exp.sol
+++ b/src/test/RFB_exp.sol
@@ -19,7 +19,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 23_649_423);
+        cheats.createSelectFork(bsc, 23_649_423);
     }
 
     function testExploit() public payable {

--- a/src/test/RL_exp.sol
+++ b/src/test/RL_exp.sol
@@ -47,7 +47,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 21_794_289);
+        cheats.createSelectFork(bsc, 21_794_289);
     }
 
     function testExploit() external {

--- a/src/test/ROI_exp.sol
+++ b/src/test/ROI_exp.sol
@@ -26,7 +26,7 @@ contract Attacker is Test {
     IPancakePair constant busdroiPair = IPancakePair(0x745D6Dd206906dd32b3f35E00533AD0963805124); // BUSD/ROI Pair
 
     function setUp() public {
-        cheat.createSelectFork("bsc", 21_143_795);
+        cheat.createSelectFork(bsc, 21_143_795);
         cheat.deal(address(this), 5 ether);
         cheat.label(address(ROI), "ROI");
         cheat.label(address(busd), "BUSD");

--- a/src/test/RabbyWallet_SwapRouter.exp.sol
+++ b/src/test/RabbyWallet_SwapRouter.exp.sol
@@ -46,7 +46,7 @@ address constant usdc = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
 
 contract Attacker is Test {
     function setUp() public {
-        cheat.createSelectFork("mainnet", 15_724_451);
+        cheat.createSelectFork(eth, 15_724_451);
         cheat.label(attacker, "attacker");
         cheat.label(RabbySwapRouter, "RabbySwapRouter");
         cheat.label(usdt, "USDT");

--- a/src/test/RariCapital_exp.sol
+++ b/src/test/RariCapital_exp.sol
@@ -21,7 +21,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 12_394_009); //fork bsc at block 12394009
+        cheats.createSelectFork(eth, 12_394_009); //fork bsc at block 12394009
     }
 
     function testExploit() public {

--- a/src/test/Rari_exp.t.sol
+++ b/src/test/Rari_exp.t.sol
@@ -18,7 +18,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 14_684_813); //fork mainnet at 14684813
+        cheats.createSelectFork(eth, 14_684_813); //fork mainnet at 14684813
     }
 
     function testExploit() public {

--- a/src/test/ReaperFarm.exp.sol
+++ b/src/test/ReaperFarm.exp.sol
@@ -29,7 +29,7 @@ contract Attacker is Test {
 
     function setUp() public {
         console.log("This is a simple PoC that shows how attacker abuse the ReaperVaultV2 contract");
-        cheat.createSelectFork("fantom", 44_045_899);
+        cheat.createSelectFork(fantom, 44_045_899);
         cheat.label(address(ReaperVault), "ReaperVault");
         cheat.label(address(USDC), "USDC");
     }

--- a/src/test/RedactedCartel_exp.sol
+++ b/src/test/RedactedCartel_exp.sol
@@ -22,7 +22,7 @@ contract RedactedCartelExploit is DSTest {
     address owner = 0x20B92862dcb9976E0AA11fAE766343B7317aB349; //owner of wxBTRFLY token
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 13_908_185); //13908185
+        cheats.createSelectFork(eth, 13_908_185); //13908185
 
         // cheat.label(address(Alice), "Alice");
         // cheat.label(address(AliceContract), "AliceContract");

--- a/src/test/RevertFinance_exp.sol
+++ b/src/test/RevertFinance_exp.sol
@@ -32,7 +32,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 16_653_389);
+        cheats.createSelectFork(eth, 16_653_389);
         cheats.label(address(utils), "utils");
         cheats.label(address(USDC), "USDC");
     }

--- a/src/test/Revest_exp.sol
+++ b/src/test/Revest_exp.sol
@@ -14,7 +14,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 14_465_356); //fork mainnet at 14465356
+        cheats.createSelectFork(eth, 14_465_356); //fork mainnet at 14465356
     }
 
     function testExploit() public {

--- a/src/test/Rikkei_exp.sol
+++ b/src/test/Rikkei_exp.sol
@@ -15,7 +15,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 16_956_474); //fork bsc at block 16956474
+        cheats.createSelectFork(bsc, 16_956_474); //fork bsc at block 16956474
     }
 
     function testExploit() public {

--- a/src/test/RodeoFinance_exp.sol
+++ b/src/test/RodeoFinance_exp.sol
@@ -61,7 +61,7 @@ contract RodeoTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("arbitrum", 110_043_452);
+        cheats.createSelectFork(arbitrum, 110_043_452);
         cheats.label(address(unshETH), "unsETH");
         cheats.label(address(WETH), "WETH");
         cheats.label(address(USDC), "USDC");

--- a/src/test/RoeFinance_exp.sol
+++ b/src/test/RoeFinance_exp.sol
@@ -40,7 +40,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 16_384_469);
+        cheats.createSelectFork(eth, 16_384_469);
         cheats.label(address(roe), "ROE");
         cheats.label(address(USDC), "USDC");
         cheats.label(address(WBTC), "WBTC");

--- a/src/test/Ronin_exp.sol
+++ b/src/test/Ronin_exp.sol
@@ -23,7 +23,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 14_442_834); //fork mainnet at 14442834
+        cheats.createSelectFork(eth, 14_442_834); //fork mainnet at 14442834
     }
 
     function testExploit() public {

--- a/src/test/Rubic_exp.sol
+++ b/src/test/Rubic_exp.sol
@@ -53,7 +53,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 16_260_580);
+        cheats.createSelectFork(eth, 16_260_580);
     }
 
     function testExploit() external {

--- a/src/test/SDAO_exp.sol
+++ b/src/test/SDAO_exp.sol
@@ -32,7 +32,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 23_241_440);
+        cheats.createSelectFork(bsc, 23_241_440);
     }
 
     function testExploit() public {

--- a/src/test/SEAMAN_exp.sol
+++ b/src/test/SEAMAN_exp.sol
@@ -22,7 +22,7 @@ contract ContractTest is DSTest {
     CheatCodes constant cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheat.createSelectFork("bsc", 23_467_515);
+        cheat.createSelectFork(bsc, 23_467_515);
     }
 
     function testExploit() public {

--- a/src/test/SELLC02_exp.sol
+++ b/src/test/SELLC02_exp.sol
@@ -41,7 +41,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 28_187_317);
+        cheats.createSelectFork(bsc, 28_187_317);
         cheats.label(address(USDT), "USDT");
         cheats.label(address(QIQI), "QIQI");
         cheats.label(address(SELLC), "SELLC");

--- a/src/test/SELLC03_exp.sol
+++ b/src/test/SELLC03_exp.sol
@@ -34,7 +34,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 29_005_754);
+        cheats.createSelectFork(bsc, 29_005_754);
         cheats.label(address(WBNB), "WBNB");
         cheats.label(address(USDT), "USDT");
         cheats.label(address(SELLC), "SELLC");

--- a/src/test/SELLC_exp.sol
+++ b/src/test/SELLC_exp.sol
@@ -43,7 +43,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 28_092_673);
+        cheats.createSelectFork(bsc, 28_092_673);
         cheats.label(address(WBNB), "WBNB");
         cheats.label(address(QIQI), "QIQI");
         cheats.label(address(SELLC), "SELLC");

--- a/src/test/SHIDO_exp.sol
+++ b/src/test/SHIDO_exp.sol
@@ -46,7 +46,7 @@ contract ContractTest is Test {
 
     function setUp() public {
         deal(address(this), 0);
-        vm.createSelectFork("bsc", 29_365_171); // It is recommended to use the quicknode endpoint
+        vm.createSelectFork(bsc, 29_365_171); // It is recommended to use the quicknode endpoint
         vm.label(address(SHIDOINU), "SHIDOINU");
         vm.label(address(SHIDO), "SHIDO");
         vm.label(address(WBNB), "WBNB");

--- a/src/test/SNK_exp.sol
+++ b/src/test/SNK_exp.sol
@@ -123,7 +123,7 @@ contract SNKExp is Test, IPancakeCallee {
     address[] public parents;
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 27784455);
+        cheats.createSelectFork(bsc, 27784455);
         deal(address(SNKToken), address(this), 1000 ether);
         for (uint i = 0; i < 10; ++ i) {
             HackerTemplate t1 = new HackerTemplate();

--- a/src/test/SUT_exp.sol
+++ b/src/test/SUT_exp.sol
@@ -43,7 +43,7 @@ contract SUTTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 30_165_901);
+        cheats.createSelectFork(bsc, 30_165_901);
         cheats.label(address(WBNB), "WBNB");
         cheats.label(address(SUT), "SUT");
         cheats.label(address(Router), "Router");

--- a/src/test/SVT_exp.sol
+++ b/src/test/SVT_exp.sol
@@ -24,7 +24,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 31178238 -1);
+        cheats.createSelectFork(bsc, 31178238 -1);
     }
 
     function testExploit() public {

--- a/src/test/Saddle_exp.sol
+++ b/src/test/Saddle_exp.sol
@@ -29,7 +29,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 14_684_306);
+        cheats.createSelectFork(eth, 14_684_306);
     }
 
     function testExploit() public {

--- a/src/test/SafeDollar_exp.sol
+++ b/src/test/SafeDollar_exp.sol
@@ -95,7 +95,7 @@ contract ContractTest is DSTest{
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("polygon", 16225172); 
+        cheats.createSelectFork(polygon, 16225172); 
     }
 
     function testExploit() public payable {

--- a/src/test/Sandbox_exp.sol
+++ b/src/test/Sandbox_exp.sol
@@ -11,7 +11,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 14_163_041); //fork mainnet at block 14163041
+        cheats.createSelectFork(eth, 14_163_041); //fork mainnet at block 14163041
     }
 
     function testExploit() public {

--- a/src/test/SellToken_exp.sol
+++ b/src/test/SellToken_exp.sol
@@ -27,7 +27,7 @@ contract SellTokenExp is Test, IDODOCallee {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 28_168_034);
+        cheats.createSelectFork(bsc, 28_168_034);
         deal(address(wbnb), address(this), 10 ether);
         payable(0x0).transfer(address(this).balance);
     }

--- a/src/test/Sentiment_exp.sol
+++ b/src/test/Sentiment_exp.sol
@@ -52,7 +52,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("arbitrum", 77_026_912);
+        cheats.createSelectFork(arbitrum, 77_026_912);
         cheats.label(address(WBTC), "WBTC");
         cheats.label(address(USDT), "USDT");
         cheats.label(address(USDC), "USDC");

--- a/src/test/Shadowfi_exp.sol
+++ b/src/test/Shadowfi_exp.sol
@@ -21,7 +21,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 20_969_095);
+        cheats.createSelectFork(bsc, 20_969_095);
     }
 
     function testExploit() public {

--- a/src/test/SheepFarm2_exp.sol
+++ b/src/test/SheepFarm2_exp.sol
@@ -24,7 +24,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 23_089_184);
+        cheats.createSelectFork(bsc, 23_089_184);
     }
 
     function testExploit() public {

--- a/src/test/SheepFarm_exp.sol
+++ b/src/test/SheepFarm_exp.sol
@@ -25,7 +25,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 23_088_156);
+        cheats.createSelectFork(bsc, 23_088_156);
     }
 
     function testExploit() public payable {

--- a/src/test/Sheep_exp.sol
+++ b/src/test/Sheep_exp.sol
@@ -27,7 +27,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 25_543_755);
+        cheats.createSelectFork(bsc, 25_543_755);
     }
 
     function testExploit() public {

--- a/src/test/ShidoGlobal_exp.sol
+++ b/src/test/ShidoGlobal_exp.sol
@@ -34,7 +34,7 @@ contract ShidoTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 29365171);
+        cheats.createSelectFork(bsc, 29365171);
         cheats.label(address(WBNB), "WBNB");
         cheats.label(address(SHIDOInu), "SHIDOInu");
         cheats.label(address(SHIDO), "SHIDO");

--- a/src/test/Snood_poc.t.sol
+++ b/src/test/Snood_poc.t.sol
@@ -20,7 +20,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 14_983_660); //fork mainnet at block 14983660
+        cheats.createSelectFork(eth, 14_983_660); //fork mainnet at block 14983660
     }
 
     function testExploit() public {

--- a/src/test/SpaceGodzilla.exp.sol
+++ b/src/test/SpaceGodzilla.exp.sol
@@ -52,7 +52,7 @@ contract AttackContract is Test {
     address SpaceGodzilla = 0x2287C04a15bb11ad1358BA5702C1C95E2D13a5E0;
 
     constructor() {
-        cheat.createSelectFork("bsc", 19_523_980); // Fork BSC mainnet at block 19523981
+        cheat.createSelectFork(bsc, 19_523_980); // Fork BSC mainnet at block 19523981
         cheat.label(address(this), "AttackContract");
         cheat.label(USDT, "USDT");
         cheat.label(CakeLP, "CakeLP");

--- a/src/test/Spartan_exp.t.sol
+++ b/src/test/Spartan_exp.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.17;
 
 import "forge-std/Test.sol";
+import "./interface.sol";
 
 // @KeyInfo - Total Lost: $30.5M
 // Attacker: 0x3b6e77722e2bbe97c1cfa337b42c0939aeb83671
@@ -14,7 +15,7 @@ import "forge-std/Test.sol";
 // https://rekt.news/spartan-rekt/
 
 contract Exploit is Test {
-    IWBNB private constant WBNB = IWBNB(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
+    IWBNB private constant WBNB = IWBNB(payable(address(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c)));
     IERC20 private constant SPARTA = IERC20(0xE4Ae305ebE1AbE663f261Bc00534067C80ad677C);
 
     IUniswapV2Pair private constant CAKE_WBNB = IUniswapV2Pair(0x0eD7e52944161450477ee417DE9Cd3a859b14fD0);
@@ -22,7 +23,7 @@ contract Exploit is Test {
     ISpartanPool private constant SPT1_WBNB = ISpartanPool(0x3de669c4F1f167a8aFBc9993E4753b84b576426f);  // SPARTAN<>WBNB
 
     function setUp() public {
-        vm.createSelectFork("https://binance.llamarpc.com", 7048832);
+        vm.createSelectFork(bsc, 7048832);
     }
 
     function testExploit() public {
@@ -86,31 +87,4 @@ interface ISpartanPool {
 
     function transfer(address to, uint256 amount) external returns (bool);
     function balanceOf(address account) external view returns (uint256);
-}
-
-interface IERC20 {
-    function transfer(address to, uint256 amount) external returns (bool);
-    function approve(address spender, uint256 amount) external returns (bool);
-    function balanceOf(address account) external view returns (uint256);
-    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
-}
-
-interface IWBNB {
-    function deposit() external payable;
-    function transfer(address to, uint256 value) external returns (bool);
-    function approve(address guy, uint256 wad) external returns (bool);
-    function withdraw(uint256 wad) external;
-    function balanceOf(address) external view returns (uint256);
-}
-
-interface IUniswapV2Pair {
-    function balanceOf(address) external view returns (uint256);
-    function skim(address to) external;
-    function sync() external;
-    function swap(
-        uint256 amount0Out,
-        uint256 amount1Out,
-        address to,
-        bytes memory data
-    ) external;
 }

--- a/src/test/Starlink_exp.sol
+++ b/src/test/Starlink_exp.sol
@@ -25,7 +25,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 25_729_304);
+        cheats.createSelectFork(bsc, 25_729_304);
     }
 
     function testExploit() public {

--- a/src/test/StarsArena_exp.sol
+++ b/src/test/StarsArena_exp.sol
@@ -21,7 +21,7 @@ contract ContractTest is Test {
     bool private reenter = true;
 
     function setUp() public {
-        vm.createSelectFork("Avalanche", 36136405);
+        vm.createSelectFork(avalanche, 36136405);
     }
 
     function testExploit() public {

--- a/src/test/Sturdy_exp.sol
+++ b/src/test/Sturdy_exp.sol
@@ -101,7 +101,7 @@ contract ContractTest is Test {
     ISturdyOracle SturdyOracle = ISturdyOracle(0xe5d78eB340627B8D5bcFf63590Ebec1EF9118C89);
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 17_460_609);
+        vm.createSelectFork(eth, 17_460_609);
         vm.label(address(wstETH), "wstETH");
         vm.label(address(WETH), "WETH");
         vm.label(address(steCRV), "steCRV");

--- a/src/test/Sushi-Badger_Digg.exp.sol
+++ b/src/test/Sushi-Badger_Digg.exp.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.10;
 
 import "forge-std/Test.sol";
+import "./interface.sol";
+
 // PoC is incomplete, not sure why but Hardhat and JS gave me a severe headache ¯\_(ツ)_/¯
 /*
 Attack tx: https://etherscan.io/tx/0x0af5a6d2d8b49f68dcfd4599a0e767450e76e08a5aeba9b3d534a604d308e60b
@@ -24,7 +26,7 @@ IUniswapV2Factory(factory).feeTo() == SushiMaker, check here: https://etherscan.
 contract Exploit is Test {
     IUniswapV2Router02 private constant sushiRouter = IUniswapV2Router02(0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F);
     IUniswapV2Factory private constant sushiFactory = IUniswapV2Factory(0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac);
-    IWETH private constant WETH = IWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    IWETH private constant WETH = IWETH(payable(address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2)));
     IERC20 private constant wethBridgeToken = IERC20(0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599); // WBTC
     IERC20 private constant nonWethBridgeToken = IERC20(0x798D1bE841a82a273720CE31c822C61a67a601C3); // DIGG
     ISushiMaker private constant sushiMaker = ISushiMaker(0xE11fc0B43ab98Eb91e9836129d1ee7c3Bc95df50);
@@ -32,7 +34,7 @@ contract Exploit is Test {
     IUniswapV2Pair private wethPair; // Fake Pair Digg<>WETH
 
     function testHack() external {
-        vm.createSelectFork("https://rpc.builder0x69.io", 11_720_049);
+        vm.createSelectFork(eth, 11_720_049);
 
         IUniswapV2Pair FakePair = createAndProvideLiquidity();
         wethPair = IUniswapV2Pair(address(FakePair));
@@ -104,21 +106,6 @@ contract Exploit is Test {
 }
 
 /* -------------------- Interface -------------------- */
-interface IERC20 {
-    function transfer(address to, uint256 amount) external returns (bool);
-    function approve(address spender, uint256 amount) external returns (bool);
-    function balanceOf(address account) external view returns (uint256);
-    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
-}
-
-interface IWETH {
-    function deposit() external payable;
-    function transfer(address to, uint256 value) external returns (bool);
-    function approve(address guy, uint256 wad) external returns (bool);
-    function withdraw(uint256 wad) external;
-    function balanceOf(address) external view returns (uint256);
-}
-
 interface IUniswapV2Router02 {
     function swapExactTokensForTokens(
         uint256 amountIn,
@@ -150,20 +137,6 @@ interface IUniswapV2Router02 {
     ) external returns (uint256 amountA, uint256 amountB);
 }
 
-interface IUniswapV2Pair {
-    function approve(address spender, uint256 amount) external returns (bool);
-    function balanceOf(address) external view returns (uint256);
-    function skim(address to) external;
-    function sync() external;
-    function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes memory data) external;
-
-    function token0() external view returns (address);
-    function token1() external view returns (address);
-}
-
-interface IUniswapV2Factory {
-    function createPair(address tokenA, address tokenB) external returns (address pair);
-}
 
 interface ISushiMaker {
     function convert(address x, address y) external view returns (uint256);

--- a/src/test/Sushi_Router_exp.sol
+++ b/src/test/Sushi_Router_exp.sol
@@ -48,7 +48,7 @@ contract SushiExp is Test, IUniswapV3Pool {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 17_007_841);
+        cheats.createSelectFork(eth, 17_007_841);
 
         cheats.label(address(WETH), "WETH");
         cheats.label(address(LINK), "LINK");

--- a/src/test/Sushimiso_exp.sol
+++ b/src/test/Sushimiso_exp.sol
@@ -24,7 +24,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 13_038_771); //fork mainnet at block 13038771
+        cheats.createSelectFork(eth, 13_038_771); //fork mainnet at block 13038771
     }
 
     function testExploit() public {

--- a/src/test/SwapX_exp.sol
+++ b/src/test/SwapX_exp.sol
@@ -38,7 +38,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 26_023_088);
+        cheats.createSelectFork(bsc, 26_023_088);
         cheats.label(address(swapX), "swapX");
         cheats.label(address(DND), "DND");
         cheats.label(address(BUSD), "BUSD");

--- a/src/test/Swapos_exp.sol
+++ b/src/test/Swapos_exp.sol
@@ -28,7 +28,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 17_057_419);
+        cheats.createSelectFork(eth, 17_057_419);
         cheats.label(address(WETH), "weth");
         cheats.label(address(swpToken), "swpToken");
     }

--- a/src/test/THB_exp.sol
+++ b/src/test/THB_exp.sol
@@ -61,7 +61,7 @@ contract ContractTest is DSTest{
         
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 21785004);
+        cheats.createSelectFork(bsc, 21785004);
     }
 
     function testExploit() public{

--- a/src/test/TIFI_exp.sol
+++ b/src/test/TIFI_exp.sol
@@ -26,7 +26,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 23_778_726);
+        cheats.createSelectFork(bsc, 23_778_726);
     }
 
     function testExploit() public {

--- a/src/test/TINU_exp.t.sol
+++ b/src/test/TINU_exp.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.17;
 
 import "forge-std/Test.sol";
+import "./interface.sol";
 
 // Total lost: 22 ETH
 // Attacker: 0x14d8ada7a0ba91f59dc0cb97c8f44f1d177c2195
@@ -14,7 +15,7 @@ import "forge-std/Test.sol";
 // https://twitter.com/libevm/status/1618731761894309889
 
 contract TomInuExploit is Test {
-    IWETH private constant WETH = IWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    IWETH private constant WETH = IWETH(payable(address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2)));
     reflectiveERC20 private constant TINU = reflectiveERC20(0x2d0E64B6bF13660a4c0De42a0B88144a7C10991F);
 
     IBalancerVault private constant balancerVault = IBalancerVault(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
@@ -22,7 +23,7 @@ contract TomInuExploit is Test {
     IUniswapV2Pair private constant TINU_WETH = IUniswapV2Pair(0xb835752Feb00c278484c464b697e03b03C53E11B);
 
     function testHack() external {
-        vm.createSelectFork("https://eth.llamarpc.com", 16489408);
+        vm.createSelectFork(eth, 16489408);
 
         // flashloan WETH from Balancer
         address[] memory tokens = new address[](1);
@@ -100,41 +101,3 @@ interface reflectiveERC20 {
     function deliver(uint256 tAmount) external;
 }
 
-interface IWETH {
-    function deposit() external payable;
-    function transfer(address to, uint256 value) external returns (bool);
-    function approve(address guy, uint256 wad) external returns (bool);
-    function withdraw(uint256 wad) external;
-    function balanceOf(address) external view returns (uint256);
-}
-
-interface IBalancerVault {
-    function flashLoan(
-        address recipient,
-        address[] memory tokens,
-        uint256[] memory amounts,
-        bytes memory userData
-    ) external;
-}
-
-interface IRouter {
-    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
-        uint256 amountIn,
-        uint256 amountOutMin,
-        address[] calldata path,
-        address to,
-        uint256 deadline
-    ) external;
-}
-
-interface IUniswapV2Pair {
-    function balanceOf(address) external view returns (uint256);
-    function skim(address to) external;
-    function sync() external;
-    function swap(
-        uint256 amount0Out,
-        uint256 amount1Out,
-        address to,
-        bytes memory data
-    ) external;
-}

--- a/src/test/TeamFinance.exp.sol
+++ b/src/test/TeamFinance.exp.sol
@@ -52,7 +52,7 @@ contract Attacker is Test {
     // And here: https://www.geogebra.org/solver?i=79210883607084793911461085816%3Dsqrt(x)*2%5E(96)
 
     function setUp() public {
-        cheat.createSelectFork("mainnet", 15_837_893);
+        cheat.createSelectFork(eth, 15_837_893);
         cheat.label(weth, "WETH");
         cheat.label(usdc, "USDC");
         cheat.label(dai, "DAI");

--- a/src/test/Templedao_exp.sol
+++ b/src/test/Templedao_exp.sol
@@ -27,7 +27,7 @@ contract ContractTest is DSTest {
     IStaxLPStaking StaxLPStaking = IStaxLPStaking(0xd2869042E12a3506100af1D192b5b04D65137941);
 
     function setUp() public {
-        cheat.createSelectFork("mainnet", 15_725_066); // fork mainnet at block 15725066
+        cheat.createSelectFork(eth, 15_725_066); // fork mainnet at block 15725066
     }
 
     function testExploit() public {

--- a/src/test/Themis_exp.sol
+++ b/src/test/Themis_exp.sol
@@ -68,7 +68,7 @@ contract ThemisTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("arbitrum", 105_524_523);
+        cheats.createSelectFork(arbitrum, 105_524_523);
         cheats.label(address(WETH), "WETH");
         cheats.label(address(AaveV3), "AaveV3");
         cheats.label(address(UniPool1), "UniPool1");

--- a/src/test/Thena_exp.sol
+++ b/src/test/Thena_exp.sol
@@ -61,7 +61,7 @@ contract ContractTest is Test {
     MockThenaRewardPool mock;
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 26_834_149);
+        cheats.createSelectFork(bsc, 26_834_149);
         cheats.label(address(THENA), "THENA");
         cheats.label(address(USDC), "USDC");
         cheats.label(address(BUSD), "BUSD");

--- a/src/test/ThoreumFinance_exp.sol
+++ b/src/test/ThoreumFinance_exp.sol
@@ -34,7 +34,7 @@ contract Attacker is Test {
         cheat.label(exploiter, "exploiter");
         cheat.label(wbnb_addr, "wbnb");
         cheat.label(wbnb_thoreum_lp_addr, "wbnb_thoreum_lp");
-        cheat.createSelectFork("bsc", 24_913_171);
+        cheat.createSelectFork(bsc, 24_913_171);
     }
 
     function testExploit() public {

--- a/src/test/TransitSwap_exp.sol
+++ b/src/test/TransitSwap_exp.sol
@@ -29,7 +29,7 @@ contract ContractTest is Test {
     IERC20 busd = IERC20(0x55d398326f99059fF775485246999027B3197955);
 
     function setUp() public {
-        vm.createSelectFork("bsc", 21_816_545); // fork mainnet block number 21816545
+        vm.createSelectFork(bsc, 21_816_545); // fork mainnet block number 21816545
     }
 
     function testExploit() public {

--- a/src/test/TreasureDAO_exp.sol
+++ b/src/test/TreasureDAO_exp.sol
@@ -12,7 +12,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("arbitrum", 7_322_694); //fork arbitrum at block 7322694
+        cheats.createSelectFork(arbitrum, 7_322_694); //fork arbitrum at block 7322694
     }
 
     function testExploit() public {

--- a/src/test/UEarnPool_exp.sol
+++ b/src/test/UEarnPool_exp.sol
@@ -60,7 +60,7 @@ contract ContractTest is DSTest {
     CheatCodes constant cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheat.createSelectFork("bsc", 23_120_167);
+        cheat.createSelectFork(bsc, 23_120_167);
     }
 
     function testExploit() public {

--- a/src/test/UFDao_exp.sol
+++ b/src/test/UFDao_exp.sol
@@ -33,7 +33,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 24_705_058);
+        cheats.createSelectFork(bsc, 24_705_058);
         cheats.label(address(shop), "SHOP");
         cheats.label(address(USDC), "USDC");
         cheats.label(address(UFT), "UFT");

--- a/src/test/ULME_exp.sol
+++ b/src/test/ULME_exp.sol
@@ -38,7 +38,7 @@ contract Attacker is DSTest {
         cheat.label(address(USDT), "USDT");
         cheat.label(address(ULME), "ULME");
 
-        cheat.createSelectFork("bsc", 22476695);
+        cheat.createSelectFork(bsc, 22476695);
         console.log("-------------------------------- Start Attacker ----------------------------------");
     }
 

--- a/src/test/ULME_exp2.sol
+++ b/src/test/ULME_exp2.sol
@@ -46,7 +46,7 @@ contract ULMEAttacker is Test {
     IULME constant ulme = IULME(0xAE975a25646E6eB859615d0A147B909c13D31FEd);
 
     function setUp() public {
-        cheats.createSelectFork("bsc");
+        cheats.createSelectFork(bsc);
         cheats.label(address(usdt), "USDT");
         cheats.label(address(dodo1), "dodo1");
         cheats.label(address(dodo2), "dodo2");

--- a/src/test/UN_exp.sol
+++ b/src/test/UN_exp.sol
@@ -21,7 +21,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 28_864_173);
+        cheats.createSelectFork(bsc, 28_864_173);
         cheats.label(address(DPPOracle), "DPPOracle");
         cheats.label(address(BUSD), "BUSD");
         cheats.label(address(UN), "UN");

--- a/src/test/USDs_exp.sol
+++ b/src/test/USDs_exp.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.10;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
+import "./interface.sol";
 
 // @Analysis
 // https://twitter.com/danielvf/status/1621965412832350208
@@ -22,7 +23,7 @@ contract USDsTest is Test {
     address ATTACKER_CONTRACT = address(0xdeadbeef);
 
     function setUp() public {
-        vm.createSelectFork("arbitrum", 57_803_529);
+        vm.createSelectFork(arbitrum, 57_803_529);
 
         vm.label(address(usds), "USDs");
         vm.label(0x97A7E6Cf949114Fe4711018485D757b9c4962307, "USDsImpl");

--- a/src/test/Uerii_exp.sol
+++ b/src/test/Uerii_exp.sol
@@ -23,7 +23,7 @@ contract ContractTest is DSTest{
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 15767837);
+        cheats.createSelectFork(eth, 15767837);
     }
 
     function testExploit() public{

--- a/src/test/Umbrella_exp.sol
+++ b/src/test/Umbrella_exp.sol
@@ -22,7 +22,7 @@ contract AttackContract is Test {
     IERC20 constant uniLP = IERC20(0xB1BbeEa2dA2905E6B0A30203aEf55c399C53D042);
 
     function setUp() public {
-        cheat.createSelectFork("mainnet", 14421983);    // Fork mainnet at block 14421983
+        cheat.createSelectFork(eth, 14421983);    // Fork mainnet at block 14421983
     }
 
     function testExploit() public {

--- a/src/test/Upswing_exp.sol
+++ b/src/test/Upswing_exp.sol
@@ -27,7 +27,7 @@ contract UpswingExploit is Test {
     address weth = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 16_433_820); // Fork mainnet at block 16433820
+        vm.createSelectFork(eth, 16_433_820); // Fork mainnet at block 16433820
         vm.label(address(uniRouter), "uniRouterV2");
         vm.label(upsToken, "upsToken");
         vm.label(weth, "weth");

--- a/src/test/Uranium_exp.sol
+++ b/src/test/Uranium_exp.sol
@@ -32,7 +32,7 @@ interface IWrappedNative {
 
 contract Exploit is Test {
     function setUp() public {
-        cheat.createSelectFork("bsc", 6_920_000);
+        cheat.createSelectFork(bsc, 6_920_000);
     }
 
     function testExploit() public {

--- a/src/test/Utopia_exp.sol
+++ b/src/test/Utopia_exp.sol
@@ -30,7 +30,7 @@ contract UtopiaTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 30119396);
+        cheats.createSelectFork(bsc, 30119396);
         cheats.label(address(WBNB), "WBNB");
         cheats.label(address(Utopia), "Utopia");
         cheats.label(address(Router), "Router");

--- a/src/test/Uwerx_exp.sol
+++ b/src/test/Uwerx_exp.sol
@@ -25,7 +25,7 @@ contract ContractTest is Test {
     Uni_Pair_V2 pair = Uni_Pair_V2(0xa41529982BcCCDfA1105C6f08024DF787CA758C4);
     
     function setUp() public {
-        vm.createSelectFork("https://eth.llamarpc.com", 17826202);
+        vm.createSelectFork(eth, 17826202);
         vm.label(address(WETH), "WETH");
         vm.label(address(WERX), "WERX");
         vm.label(address(Router), "Router");

--- a/src/test/VINU_exp.sol
+++ b/src/test/VINU_exp.sol
@@ -29,7 +29,7 @@ contract VinuTest is Test {
 
     function setUp() public {
         deal(address(this), 0.5 ether);
-        cheats.createSelectFork("mainnet", 17_421_006);
+        cheats.createSelectFork(eth, 17_421_006);
         cheats.label(address(VINU), "VINU");
         cheats.label(address(WETH), "WETH");
         cheats.label(address(UniswapV2Router02), "UniswapV2Router02");

--- a/src/test/VTF_exp.sol
+++ b/src/test/VTF_exp.sol
@@ -50,7 +50,7 @@ contract ContractTest is DSTest {
 
     // ankr rpc bsc maybe unavailible, please use QuickNode
     function setUp() public {
-        cheat.createSelectFork("bsc", 22_535_101);
+        cheat.createSelectFork(bsc, 22_535_101);
     }
 
     function testExploit() public {

--- a/src/test/ValueDefi_exp.sol
+++ b/src/test/ValueDefi_exp.sol
@@ -31,7 +31,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 7_223_029); //fork bsc at block 7223029
+        cheats.createSelectFork(bsc, 7_223_029); //fork bsc at block 7223029
     }
 
     function testExploit() public {

--- a/src/test/Visor_exp.t.sol
+++ b/src/test/Visor_exp.t.sol
@@ -11,7 +11,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 13_849_006); //fork mainnet at block 13849006
+        cheats.createSelectFork(eth, 13_849_006); //fork mainnet at block 13849006
     }
 
     function testExploit() public {

--- a/src/test/WGPT_exp.sol
+++ b/src/test/WGPT_exp.sol
@@ -55,7 +55,7 @@ contract WGPTTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 29891709);
+        cheats.createSelectFork(bsc, 29891709);
         cheats.label(address(BUSDT), "BUSDT");
         cheats.label(address(ExpToken), "ExpToken");
         cheats.label(address(WGPT), "WGPT");

--- a/src/test/WaultFinance_exp.sol
+++ b/src/test/WaultFinance_exp.sol
@@ -29,7 +29,7 @@ contract ContractTest is DSTest{
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 9728755);
+        cheats.createSelectFork(bsc, 9728755);
     }
 
     function testExploit() public{

--- a/src/test/Wdoge_exp.sol
+++ b/src/test/Wdoge_exp.sol
@@ -13,7 +13,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 17_248_705); //fork bsc at block 17248705
+        cheats.createSelectFork(bsc, 17_248_705); //fork bsc at block 17248705
     }
 
     function testExploit() public {

--- a/src/test/WiseLending_exp.sol
+++ b/src/test/WiseLending_exp.sol
@@ -49,7 +49,7 @@ contract ContractTest is Test {
     Recover recover;
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 18_342_120);
+        vm.createSelectFork(eth, 18_342_120);
         vm.label(address(WBTC), "WBTC");
         vm.label(address(wstETH), "wstETH");
         vm.label(address(WETH), "WETH");

--- a/src/test/XCarnival.exp.sol
+++ b/src/test/XCarnival.exp.sol
@@ -113,7 +113,7 @@ contract mainAttackContract is DSTest {
     CheatCodes cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheat.createSelectFork("mainnet", 15_028_846); // fork mainnet at block 15028846
+        cheat.createSelectFork(eth, 15_028_846); // fork mainnet at block 15028846
 
         cheat.deal(address(this), 0);
         emit log_named_decimal_uint("[*] Attacker Contract ETH Balance", address(this).balance, 18);

--- a/src/test/XSDWETHpool_exp.sol
+++ b/src/test/XSDWETHpool_exp.sol
@@ -71,7 +71,7 @@ contract ContractTest is Test {
     uint exploitAmount = 56_964_339_410_199_718_035;
 
     function setUp() public {
-        vm.createSelectFork("bsc", 32086901 - 1);
+        vm.createSelectFork(bsc, 32086901 - 1);
         vm.label(address(WBNB), "WBNB");
         vm.label(address(DPPOracle), "DPPOracle");
         vm.label(address(DPPAdvance), "DPPAdvance");

--- a/src/test/XST.exp.sol
+++ b/src/test/XST.exp.sol
@@ -18,7 +18,7 @@ contract XSTExpTest is Test {
     CheatCodes constant cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheat.createSelectFork("mainnet", 15_310_016);
+        cheat.createSelectFork(eth, 15_310_016);
     }
 
     function testExploit() public {

--- a/src/test/XST02_exp.sol
+++ b/src/test/XST02_exp.sol
@@ -19,7 +19,7 @@ contract ContractTest is DSTest {
     CheatCodes cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheat.createSelectFork("mainnet", 15_310_016);
+        cheat.createSelectFork(eth, 15_310_016);
     }
 
     function testExploit() public {

--- a/src/test/XSURGE_exp.t.sol
+++ b/src/test/XSURGE_exp.t.sol
@@ -30,7 +30,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 10_087_723); // fork bsc at block 10087723
+        cheats.createSelectFork(bsc, 10_087_723); // fork bsc at block 10087723
     }
 
     function testExploit() public {

--- a/src/test/XaveFinance_exp.sol
+++ b/src/test/XaveFinance_exp.sol
@@ -60,7 +60,7 @@ contract XaveFinanceExploit is DSTest {
     address attackerContract = 0xE167cdAAc8718b90c03Cf2CB75DC976E24EE86D3;
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 15_704_736); // fork mainnet at 15704736
+        cheats.createSelectFork(eth, 15_704_736); // fork mainnet at 15704736
     }
 
     function encodeWithSignature_mint(address to, uint256 amount) internal pure returns (bytes memory) {

--- a/src/test/YearnFinance_exp.sol
+++ b/src/test/YearnFinance_exp.sol
@@ -423,7 +423,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() external {
-        cheats.createSelectFork("mainnet", 17_036_774);
+        cheats.createSelectFork(eth, 17_036_774);
     }
 
     //tx:0x055cec4fa4614836e54ea2e5cd3d14247ff3d61b85aa2a41f8cc876d131e0328

--- a/src/test/Yyds_exp.sol
+++ b/src/test/Yyds_exp.sol
@@ -25,7 +25,7 @@ contract ContractTest is DSTest {
     uint256 reserve1;
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 21_157_025);
+        cheats.createSelectFork(bsc, 21_157_025);
     }
 
     function testExploit() public {

--- a/src/test/ZABU_exp.sol
+++ b/src/test/ZABU_exp.sol
@@ -75,7 +75,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("Avalanche", 4_177_751);
+        cheats.createSelectFork(avalanche, 4_177_751);
     }
 
     function testExploit() public payable {

--- a/src/test/Zeed_exp.sol
+++ b/src/test/Zeed_exp.sol
@@ -15,7 +15,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 17_132_514); // fork bsc at block 17132514
+        cheats.createSelectFork(bsc, 17_132_514); // fork bsc at block 17132514
     }
 
     function testExploit() public {

--- a/src/test/ZoomproFinance_exp.sol
+++ b/src/test/ZoomproFinance_exp.sol
@@ -39,7 +39,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 21_055_930); //fork bsc at block number 21055930
+        cheats.createSelectFork(bsc, 21_055_930); //fork bsc at block number 21055930
     }
 
     function testExploit() public {

--- a/src/test/Zunami_exp.sol
+++ b/src/test/Zunami_exp.sol
@@ -56,7 +56,7 @@ contract ContractTest is Test {
     address MIMCurveStakeDao = 0x9848EDb097Bee96459dFf7609fb582b80A8F8EfD;
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 17_908_949);
+        vm.createSelectFork(eth, 17_908_949);
         vm.label(address(WETH), "WETH");
         vm.label(address(USDC), "USDC");
         vm.label(address(UZD), "UZD");

--- a/src/test/cftoken_exp.sol
+++ b/src/test/cftoken_exp.sol
@@ -32,7 +32,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 16_841_980); //fork bsc at block 16841980
+        cheats.createSelectFork(bsc, 16_841_980); //fork bsc at block 16841980
     }
 
     function testExploit() public {

--- a/src/test/dForce_exp.sol
+++ b/src/test/dForce_exp.sol
@@ -80,7 +80,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("arbitrum", 59_527_633);
+        cheats.createSelectFork(arbitrum, 59_527_633);
         cheats.label(address(WETH), "WETH");
         cheats.label(address(USDC), "USDC");
         cheats.label(address(USX), "USX");

--- a/src/test/deus_exp.sol
+++ b/src/test/deus_exp.sol
@@ -28,7 +28,7 @@ contract ContractTest is DSTest {
     IOracle oracle = IOracle(0x8129026c585bCfA530445a6267f9389057761A00);
 
     function setUp() public {
-        cheat.createSelectFork("fantom", 37_093_708); // fork fantom at block 37093708
+        cheat.createSelectFork(fantom, 37_093_708); // fork fantom at block 37093708
     }
 
     function testExample() public {

--- a/src/test/dodo_flashloan_exp.sol
+++ b/src/test/dodo_flashloan_exp.sol
@@ -26,7 +26,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 12_000_000); // fork mainnet block number 12000000
+        cheats.createSelectFork(eth, 12_000_000); // fork mainnet block number 12000000
     }
 
     function testExploit() public {

--- a/src/test/interface.sol
+++ b/src/test/interface.sol
@@ -3,6 +3,7 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 import "forge-std/Test.sol";
+import "./rpc.sol";
 
 interface CheatCodes {
     // This allows us to getRecordedLogs()
@@ -387,6 +388,7 @@ interface IUniswapV2Pair {
     function approve(address spender, uint value) external returns (bool);
     function transfer(address to, uint value) external returns (bool);
     function transferFrom(address from, address to, uint value) external returns (bool);
+    function sync() external;
 }
 
 interface IBacon {
@@ -3440,6 +3442,14 @@ interface IRouter {
         address to,
         uint256 deadline
     ) external;
+    
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external;
 }
 
 interface ILendingPool {
@@ -3487,10 +3497,11 @@ interface IAggregator {
 
 interface CErc20Interface {
     function mint(uint256 mintAmount) external returns (uint256);
-
     function balanceOf(address account) external view returns (uint256);
-
     function borrow(uint256 borrowAmount) external returns (uint256);
+    function redeem(uint256 amount) external;
+    function withdrawAll() external;
+    function transfer(address to, uint256 amount) external returns (bool);
 }
 
 interface IUSDT {
@@ -3799,6 +3810,8 @@ interface ICurvePool {
         uint256 token_amount,
         uint256[3] memory min_amounts
     ) external returns (uint256[3] memory);
+
+    function remove_liquidity(uint256 _amount, uint256[2] calldata min_amounts, bool donate_dust) external;
 
     function remove_liquidity_imbalance(uint256[3] memory amounts, uint256 max_burn_amount) external;
 

--- a/src/test/landNFT_exp.sol
+++ b/src/test/landNFT_exp.sol
@@ -23,7 +23,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 28208132);
+        cheats.createSelectFork(bsc, 28208132);
         cheats.label(address(landNFT), "landNFT");
         cheats.label(address(minerContract), "Miner");
     }

--- a/src/test/pSeudoEth_exp.sol
+++ b/src/test/pSeudoEth_exp.sol
@@ -26,7 +26,7 @@ contract ContractTest is Test {
 
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 18_305_132 - 1);
+        vm.createSelectFork(eth, 18_305_132 - 1);
         vm.label(address(WETH), "WETH");
         vm.label(address(Balancer), "Balancer");
         vm.label(address(UniRouter), "Uniswap V2: Router");

--- a/src/test/paraspace_exp.sol
+++ b/src/test/paraspace_exp.sol
@@ -27,7 +27,7 @@ contract ContractTest is DSTest {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 16_845_558);
+        cheats.createSelectFork(eth, 16_845_558);
         cheats.label(0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0, "_wstETH");
         cheats.label(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, "_WETH");
         cheats.label(0xDDDe38696FBe5d11497D72d8801F651642d62353, "_pcAPE");

--- a/src/test/poolz_exp.sol
+++ b/src/test/poolz_exp.sol
@@ -25,7 +25,7 @@ contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("bsc", 26_475_403);
+        cheats.createSelectFork(bsc, 26_475_403);
     }
 
     function testExploit() external {

--- a/src/test/rpc.sol
+++ b/src/test/rpc.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.7.0 <0.9.0;
+
+string constant eth = "https://eth.llamarpc.com";
+string constant bsc = "https://bscrpc.com";
+string constant polygon = "https://polygon.llamarpc.com";
+string constant optimism = "https://rpc.ankr.com/optimism";
+string constant arbitrum = "https://rpc.ankr.com/arbitrum";
+string constant avalanche = "https://avalanche.drpc.org";
+string constant fantom = "https://rpc3.fantom.network";
+string constant gnosis = "https://gnosis.publicnode.com";
+string constant base = "https://mainnet.base.org";
+string constant moonriver = "https://moonriver.public.blastapi.io";

--- a/src/test/safeMoon_exp.sol
+++ b/src/test/safeMoon_exp.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
+import "./interface.sol";
 
 interface IUniswapV2Router02 {
     function WETH() external pure returns (address);
@@ -43,35 +44,6 @@ interface ISafeSwapTradeRouter {
     ) external payable;
 }
 
-interface IWETH {
-    function approve(address, uint) external returns (bool);
-
-    function transfer(address, uint) external returns (bool);
-
-    function balanceOf(address) external view returns (uint);
-}
-
-interface IPancakePair {
-    function swap(
-        uint amount0Out,
-        uint amount1Out,
-        address to,
-        bytes calldata data
-    ) external;
-}
-
-interface IPancakeCallee {
-    function pancakeCall(
-        address sender,
-        uint amount0,
-        uint amount1,
-        bytes calldata data
-    ) external;
-}
-
-interface IUniswapV2Pair {
-    function sync() external;
-}
 
 contract SafemoonAttackerTest is Test, IPancakeCallee {
     ISafemoon public sfmoon;
@@ -79,11 +51,11 @@ contract SafemoonAttackerTest is Test, IPancakeCallee {
     IWETH public weth;
 
     function setUp() public {
-        vm.createSelectFork("https://rpc.ankr.com/bsc", 26854757);
+        vm.createSelectFork(bsc, 26854757);
 
         sfmoon = ISafemoon(0x42981d0bfbAf196529376EE702F2a9Eb9092fcB5);
         pancakePair = IPancakePair(0x1CEa83EC5E48D9157fCAe27a19807BeF79195Ce1);
-        weth = IWETH(sfmoon.uniswapV2Router().WETH());
+        weth = IWETH(payable(address(sfmoon.uniswapV2Router().WETH())));
     }
 
     function testMint() public {

--- a/src/test/silo_finance.t.sol
+++ b/src/test/silo_finance.t.sol
@@ -127,7 +127,7 @@ contract SiloBugFixReviewTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function setUp() public {
-        cheats.createSelectFork("mainnet", 17_139_470);
+        cheats.createSelectFork(eth, 17_139_470);
 
         siloBugFixReview = new SiloBugFixReview();
         deal(address(siloBugFixReview.WETH()), address(siloBugFixReview), depositAmount + donatedAmount);

--- a/src/test/uniclyNFT_exp.sol
+++ b/src/test/uniclyNFT_exp.sol
@@ -45,7 +45,7 @@ contract ContractTest is Test {
         IERC721(0x7AFe30cB3E53dba6801aa0EA647A0EcEA7cBe18d);
 
     function setUp() public {
-        vm.createSelectFork("mainnet", 18133171);
+        vm.createSelectFork(eth, 18133171);
         vm.label(address(WETH), "WETH");
         vm.label(address(uJENNY), "uJENNY");
         vm.label(address(uJENNY_WETH), "uJENNY_WETH");

--- a/src/test/xWin_exp.sol
+++ b/src/test/xWin_exp.sol
@@ -92,7 +92,7 @@ contract XWinExpTest is Test {
     address payable private repayAddr = payable(0xc78248D676DeBB4597e88071D3d889eCA70E5469);
 
     function setUp() public {
-        cheat.createSelectFork("bsc",8589725);
+        cheat.createSelectFork(bsc,8589725);
         deal(address(this), 0);
     }
     function testExploit() external {


### PR DESCRIPTION
In this commit,  I've introduced a new file named rpc.sol that contains RPC URLs for various blockchain networks. Previously, users had to manually specify the RPC URL each time they ran the script, which was inconvenient.
To address this, I've modified the exploit script to automatically fetch the RPC URL from the rpc.sol file. This change simplifies the execution of the exploit script and contributes to a smoother experience.

Please review and provide feedback.