### PR TITLE
fix: use Test instead of DSTest

### DIFF
--- a/src/test/88mph_exp.sol
+++ b/src/test/88mph_exp.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.10;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     I88mph mphNFT = I88mph(0xF0b7DE03134857391d8D43Ed48e20EDF21461097);
 

--- a/src/test/AES_exp.sol
+++ b/src/test/AES_exp.sol
@@ -14,7 +14,7 @@ interface IAES is IERC20 {
     function distributeFee() external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IAES AES = IAES(0xdDc0CFF76bcC0ee14c3e73aF630C029fe020F907);
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
     Uni_Pair_V2 Pair = Uni_Pair_V2(0x40eD17221b3B2D8455F4F1a05CAc6b77c5f707e3);

--- a/src/test/ANCH_exp.sol
+++ b/src/test/ANCH_exp.sol
@@ -9,7 +9,7 @@ import "./interface.sol";
 // @Contract address
 // https://bscscan.com/address/0xa4f5d4afd6b9226b3004dd276a9f778eb75f2e9e#code
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 ANCH = IERC20(0xA4f5d4aFd6b9226b3004dD276A9F778EB75f2e9e);
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
     Uni_Pair_V2 Pair = Uni_Pair_V2(0xaD0dA05b9C20fa541012eE2e89AC99A864CC68Bb);

--- a/src/test/APC_exp.sol
+++ b/src/test/APC_exp.sol
@@ -14,7 +14,7 @@ interface TransparentUpgradeableProxy {
     function swap(address a1, address a2, uint256 amount) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 APC = IERC20(0x2AA504586d6CaB3C59Fa629f74c586d78b93A025);
     IERC20 MUSD = IERC20(0x473C33C55bE10bB53D81fe45173fcc444143a13e);
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);

--- a/src/test/AUR_exp.sol
+++ b/src/test/AUR_exp.sol
@@ -25,7 +25,7 @@ interface IAurumNodePool {
     function getNodes(address account) external view returns (NodeEntity[] memory nodes);
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 AUR = IERC20(0x73A1163EA930A0a67dFEFB9C3713Ef0923755B78);
     IERC20 WBNB = IERC20(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
 

--- a/src/test/AkutarNFT_exp.sol
+++ b/src/test/AkutarNFT_exp.sol
@@ -15,7 +15,7 @@ There are two serious logic vulnerabilities
 
 forge test --contracts ./src/test/AkutarNFT_exp.sol -vv  
 */
-contract AkutarNFTExploit is DSTest {
+contract AkutarNFTExploit is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     IAkutarNFT akutarNft = IAkutarNFT(0xF42c318dbfBaab0EEE040279C6a2588Fa01a961d);
 

--- a/src/test/Annex_exp.sol
+++ b/src/test/Annex_exp.sol
@@ -9,7 +9,7 @@ import "./interface.sol";
 // @TX
 // https://bscscan.com/tx/0x3757d177482171dcfad7066c5e88d6f0f0fe74b28f32e41dd77137cad859c777
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 WBNB = IERC20(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
     Uni_Router_V2 Router = Uni_Router_V2(0x10ED43C718714eb63d5aA57B78B54704E256024E);
     IUniswapV2Factory Factory = IUniswapV2Factory(0xcA143Ce32Fe78f1f7019d7d551a6402fC5350c73);

--- a/src/test/Anyswap_poc.t.sol
+++ b/src/test/Anyswap_poc.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.10;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     address WETH_Address = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     AnyswapV4Router any = AnyswapV4Router(0x6b7a87899490EcE95443e979cA9485CBE7E71522);

--- a/src/test/BBOX_exp.sol
+++ b/src/test/BBOX_exp.sol
@@ -9,7 +9,7 @@ import "./interface.sol";
 // @TX
 // https://bscscan.com/tx/0xac57c78881a7c00dfbac0563e21b5ae3a8e3f9d1b07198a27313722a166cc0a3
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 BBOX = IERC20(0x5DfC7f3EbBB9Cbfe89bc3FB70f750Ee229a59F8c);
     IERC20 WBNB = IERC20(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
     Uni_Router_V2 Router = Uni_Router_V2(0x10ED43C718714eb63d5aA57B78B54704E256024E);

--- a/src/test/BDEX_exp.sol
+++ b/src/test/BDEX_exp.sol
@@ -19,7 +19,7 @@ interface BPair {
     function getReserves() external view returns (uint112 _reserve0, uint112 _reserve1, uint32 _blockTimestampLast);
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 WBNB = IERC20(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
     IERC20 BDEX = IERC20(0x7E0F01918D92b2750bbb18fcebeEDD5B94ebB867);
     BvaultsStrategy vaultsStrategy = BvaultsStrategy(0xB2B1DC3204ee8899d6575F419e72B53E370F6B20);

--- a/src/test/BEC_exp.sol
+++ b/src/test/BEC_exp.sol
@@ -13,7 +13,7 @@ interface BECToken {
 // https://etherscan.io/tx/0xad89ff16fd1ebe3a0a7cf4ed282302c06626c1af33221ebe0d3a470aba4a660f
 // https://etherscan.io/address/0xc5d105e63711398af9bbff092d4b6769c82f793d#code  Line261
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     address attacker1 = 0xb4D30Cac5124b46C2Df0CF3e3e1Be05f42119033;
     address attacker2 = 0x0e823fFE018727585EaF5Bc769Fa80472F76C3d7;
     BECToken bec = BECToken(0xC5d105E63711398aF9bbff092d4B6769C82F793D);

--- a/src/test/BGLD_exp.sol
+++ b/src/test/BGLD_exp.sol
@@ -13,7 +13,7 @@ interface ERCPorxy {
     function migrate() external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 WBNB = IERC20(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
     IERC20 oldBGLD = IERC20(0xC2319E87280c64e2557a51Cb324713Dd8d1410a3);

--- a/src/test/BNB48MEVBot_exp.sol
+++ b/src/test/BNB48MEVBot_exp.sol
@@ -7,7 +7,7 @@ interface MEVBot {
     function pancakeCall(address sender, uint256 amount0, uint256 amount1, bytes calldata data) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     address public _token0;
     address public _token1;
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);

--- a/src/test/Bacon_exp.sol
+++ b/src/test/Bacon_exp.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     IUniswapV2Pair pair = IUniswapV2Pair(0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc);
     IERC20 usdc = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);

--- a/src/test/BadGuysbyRPF_exp.sol
+++ b/src/test/BadGuysbyRPF_exp.sol
@@ -15,7 +15,7 @@ Etherscan tx - https://etherscan.io/tx/0xb613c68b00c532fe9b28a50a91c021d61a98d90
 
 forge test --contracts ./src/test/BadGuysbyRPF_exp.sol -vv*/
 
-contract BadGuysbyRPFExploit is DSTest {
+contract BadGuysbyRPFExploit is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     address owner = 0x09eFF2449882F9e727A8e9498787f8ff81465Ade; //owner of Bad Guys by RPF

--- a/src/test/Bancor_exp.sol
+++ b/src/test/Bancor_exp.sol
@@ -19,7 +19,7 @@ interface IBancor {
     function safeTransferFrom(IERC20 _token, address _from, address _to, uint256 _value) external;
 }
 
-contract BancorExploit is DSTest {
+contract BancorExploit is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     address bancorAddress = 0x5f58058C0eC971492166763c8C22632B583F667f;
     address victim = 0xfd0B4DAa7bA535741E6B5Ba28Cba24F9a816E67E;

--- a/src/test/Bayc_apecoin_exp.sol
+++ b/src/test/Bayc_apecoin_exp.sol
@@ -11,7 +11,7 @@ Debug:
 https://dashboard.tenderly.co/tx/mainnet/0xeb8c3bebed11e2e4fcd30cbfc2fb3c55c4ca166003c7f7d319e78eaab9747098
 https://tools.blocksec.com/tx/eth/0xeb8c3bebed11e2e4fcd30cbfc2fb3c55c4ca166003c7f7d319e78eaab9747098*/
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     IBAYCi bayc = IBAYCi(0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D);
     INFTXVault NFTXVault = INFTXVault(0xEA47B64e1BFCCb773A0420247C0aa0a3C1D2E5C5);

--- a/src/test/Beanstalk_exp.sol
+++ b/src/test/Beanstalk_exp.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     ILendingPool aavelendingPool = ILendingPool(0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9);
     IERC20 dai = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);

--- a/src/test/BrahTOPG_exp.sol
+++ b/src/test/BrahTOPG_exp.sol
@@ -20,7 +20,7 @@ interface Zapper {
     function zapIn(ZapData calldata zapCall) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     Zapper zappper = Zapper(0xD248B30A3207A766d318C7A87F5Cf334A439446D);
     IERC20 WETH = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     IERC20 USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);

--- a/src/test/BuildF_exp.sol
+++ b/src/test/BuildF_exp.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     IBuildFinance BuildGovernance = IBuildFinance(0x5A6eBeB61A80B2a2a5e0B4D893D731358d888583);
     IERC20 build = IERC20(0x6e36556B3ee5Aa28Def2a8EC3DAe30eC2B208739);

--- a/src/test/Chainswap_exp1.sol
+++ b/src/test/Chainswap_exp1.sol
@@ -16,7 +16,7 @@ struct Signature {
 //   function receive(uint256 fromChainId, address to, uint256 nonce, uint256 volume, Signature[] memory signatures) virtual external payable;
 // }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     address exploiter = 0x941a9E3B91E1cc015702B897C512D265fAE88A9c;
     address proxy = 0x7fe68FC06e1A870DcbeE0acAe8720396DC12FC86;
     address impl = 0x373CE6Da1AEB73A9bcA412F2D3b7eD07Af3AD490;

--- a/src/test/Chainswap_exp2.sol
+++ b/src/test/Chainswap_exp2.sol
@@ -16,7 +16,7 @@ struct Signature {
 //   function receive(uint256 fromChainId, address to, uint256 nonce, uint256 volume, Signature[] memory signatures) virtual external payable;
 // }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     address exploiter = 0xEda5066780dE29D00dfb54581A707ef6F52D8113;
     address proxy = 0x089165ac9a7Bf61833Da86268F34A01652543466;
     address impl = 0xc5185d2c68aAa7c5f0921948f8135d01510D647F;

--- a/src/test/CompoundTusd_exp.sol
+++ b/src/test/CompoundTusd_exp.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.10;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     ICErc20Delegate cTUSD = ICErc20Delegate(0x12392F67bdf24faE0AF363c24aC620a2f67DAd86);
     IERC20 tusd = IERC20(0x0000000000085d4780B73119b644AE5ecd22b376);
     address tusdLegacy = 0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E;

--- a/src/test/Cover_exp.sol
+++ b/src/test/Cover_exp.sol
@@ -14,7 +14,7 @@ interface Blacksmith {
     function withdraw(address _lpToken, uint256 _amount) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     Blacksmith public bs = Blacksmith(0xE0B94a7BB45dD905c79bB1992C9879f40F1CAeD5);

--- a/src/test/Cream_2_exp.sol
+++ b/src/test/Cream_2_exp.sol
@@ -126,7 +126,7 @@ contract SecondContract {
     receive() external payable {}
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IDaiFlashloan DaiFlash = IDaiFlashloan(0x1EB4CF3A948E7D72A198fe073cCb8C7a948cD853);
     ICurvePool curvePool = ICurvePool(0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7);
     IComptroller comptroller = IComptroller(0x3d5BC3c8d13dcB8bF317092d84783c2697AE9258);

--- a/src/test/Cream_exp.sol
+++ b/src/test/Cream_exp.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     AMP amp = AMP(0xfF20817765cB7f73d4bde2e66e067E58D11095C2);
 
     IERC1820Registry ierc1820 = IERC1820Registry(0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24);

--- a/src/test/DDC_exp.sol
+++ b/src/test/DDC_exp.sol
@@ -38,7 +38,7 @@ interface IPair {
     function sync() external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 WBNB = IERC20(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
     IRouter TargetRouter = IRouter(0x22Dc25866BB53c52BAfA6cB80570FC83FC7dd125);
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);

--- a/src/test/DEI_exp.sol
+++ b/src/test/DEI_exp.sol
@@ -19,7 +19,7 @@ interface IDEI is IERC20 {
     function burnFrom(address account, uint256 amount) external;
 }
 
-contract DEIPocTest is DSTest {
+contract DEIPocTest is Test {
     IStablePair pair = IStablePair(0x7DC406b9B904a52D10E19E848521BbA2dE74888b);
     IDEI DEI = IDEI(0xDE1E704dae0B4051e80DAbB26ab6ad6c12262DA0);
     IERC20 USDC = IERC20(0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8);

--- a/src/test/DFX_exp.sol
+++ b/src/test/DFX_exp.sol
@@ -19,7 +19,7 @@ interface Curve {
     function withdraw(uint256 _curvesToBurn, uint256 _deadline) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 XIDR = IERC20(0xebF2096E01455108bAdCbAF86cE30b6e5A72aa52);
     IERC20 USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
     IERC20 WETH = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);

--- a/src/test/DPC_exp.sol
+++ b/src/test/DPC_exp.sol
@@ -17,7 +17,7 @@ interface IDPC {
     function claimDpcAirdrop(address) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IDPC DPC = IDPC(0xB75cA3C3e99747d0e2F6e75A9fBD17F5Ac03cebE);
     IERC20 WBNB = IERC20(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);

--- a/src/test/Defrost_exp.sol
+++ b/src/test/Defrost_exp.sol
@@ -17,7 +17,7 @@ interface LSWUSDC {
     function redeem(uint256 shares, address receiver, address owner) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 USDC = IERC20(0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E);
     LSWUSDC LSW = LSWUSDC(0xfF152e21C5A511c478ED23D1b89Bb9391bE6de96);
     Uni_Pair_V2 Pair = Uni_Pair_V2(0xf4003F4efBE8691B60249E6afbD307aBE7758adb);

--- a/src/test/Discover_exp.sol
+++ b/src/test/Discover_exp.sol
@@ -10,7 +10,7 @@ interface ETHpledge {
 // Expected error. [FAIL. Reason: Pancake: INSUFFICIENT_INPUT_AMOUNT]
 // Because we don't repay funds to pancake.
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IPancakePair PancakePair = IPancakePair(0x7EFaEf62fDdCCa950418312c6C91Aef321375A00);
     IPancakePair PancakePair2 = IPancakePair(0x92f961B6bb19D35eedc1e174693aAbA85Ad2425d);
     IERC20 busd = IERC20(0x55d398326f99059fF775485246999027B3197955);

--- a/src/test/ElasticSwap_exp.sol
+++ b/src/test/ElasticSwap_exp.sol
@@ -42,7 +42,7 @@ interface ELPExchange is IERC20 {
     ) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 TIC = IERC20(0x75739a693459f33B1FBcC02099eea3eBCF150cBe);
     IERC20 USDC_E = IERC20(0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664);
     Uni_Pair_V2 SPair = Uni_Pair_V2(0x4CF9dC05c715812FeAD782DC98de0168029e05C8);

--- a/src/test/Elephant_Money_poc.sol
+++ b/src/test/Elephant_Money_poc.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.10;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IWBNB wbnb = IWBNB(payable(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c));
 
     address public BUSD_USDT_Pair = 0x7EFaEf62fDdCCa950418312c6C91Aef321375A00;

--- a/src/test/Eleven.sol
+++ b/src/test/Eleven.sol
@@ -13,7 +13,7 @@ tx hash: 0x6450d8f4db09972853e948bee44f2cb54b9df786dace774106cd28820e906789
 
 https://peckshield.medium.com/eleven-finance-incident-root-cause-analysis-123b5675fa76*/
 
-contract Eleven is DSTest {
+contract Eleven is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     IPancakeRouter router = IPancakeRouter(payable(0x10ED43C718714eb63d5aA57B78B54704E256024E));

--- a/src/test/Fantasm_exp.sol
+++ b/src/test/Fantasm_exp.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.10;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     IERC20 fsm = IERC20(0xaa621D2002b5a6275EF62d7a065A865167914801);
     IERC20 xFTM = IERC20(0xfBD2945D3601f21540DDD85c29C5C3CaF108B96F);

--- a/src/test/FlippazOne.sol
+++ b/src/test/FlippazOne.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     Flippaz FlippazOne = Flippaz(0xE85A08Cf316F695eBE7c13736C8Cc38a7Cc3e944);
 

--- a/src/test/FortressLoans.exp.sol
+++ b/src/test/FortressLoans.exp.sol
@@ -40,7 +40,7 @@ address constant Vyper1 = 0x98245Bfbef4e3059535232D68821a58abB265C45;
 address constant Vyper2 = 0x1d4B4796853aEDA5Ab457644a18B703b6bA8b4aB;
 address constant PancakeRouter = 0x10ED43C718714eb63d5aA57B78B54704E256024E;
 
-contract ProposalCreateFactory is DSTest {
+contract ProposalCreateFactory is Test {
     /* Method 0xb9470ff4 */
     // 創建提案, 提案內容為: 設置 fToken 的抵押係數從 0 變更為 700000000000000000 (0.7 ether)
     function ProposalCreated() public {
@@ -66,7 +66,7 @@ contract ProposalCreateFactory is DSTest {
     }
 }
 
-contract Attack is DSTest {
+contract Attack is Test {
     /* Method 0x2b69be8e */
     function exploit() public {
         // Excute Proposal 11
@@ -256,7 +256,7 @@ contract Attack is DSTest {
     receive() external payable {}
 }
 
-contract Hacker is DSTest {
+contract Hacker is Test {
     using stdStorage for StdStorage;
 
     StdStorage stdstore;

--- a/src/test/GDS_exp.sol
+++ b/src/test/GDS_exp.sol
@@ -54,7 +54,7 @@ contract ClaimReward {
     }
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     GDSToken GDS = GDSToken(0xC1Bb12560468fb255A8e8431BDF883CC4cB3d278);
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
     IERC20 WBNB = IERC20(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);

--- a/src/test/Grim_exp.sol
+++ b/src/test/Grim_exp.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.10;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     address btcAddress = 0x321162Cd933E2Be498Cd2267a90534A804051b11;
     address wftmAddress = 0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83;
     address routerAddress = 0x16327E3FbDaCA3bcF7E38F5Af2599D2DDc33aE52;

--- a/src/test/Gym_1_exp.sol
+++ b/src/test/Gym_1_exp.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.10;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     IPancakeRouter pancakeRouter = IPancakeRouter(payable(0x10ED43C718714eb63d5aA57B78B54704E256024E));
     ILiquidityMigrationV2 liquidityMigrationV2 =

--- a/src/test/Gym_2_exp.sol
+++ b/src/test/Gym_2_exp.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.10;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     IPancakeRouter pancakeRouter = IPancakeRouter(payable(0x6CD71A07E72C514f5d511651F6808c6395353968));
     GymToken gymnet = GymToken(0x3a0d9d7764FAE860A659eb96A500F1323b411e68);

--- a/src/test/HackDao_exp.sol
+++ b/src/test/HackDao_exp.sol
@@ -9,7 +9,7 @@ import "./interface.sol";
 // @Contract address
 // https://bscscan.com/address/0x94e06c77b02ade8341489ab9a23451f68c13ec1c#code
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 HackDao = IERC20(0x94e06c77b02Ade8341489Ab9A23451F68c13eC1C);
     IERC20 WBNB = IERC20(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
     Uni_Pair_V2 Pair1 = Uni_Pair_V2(0xcd4CDAa8e96ad88D82EABDdAe6b9857c010f4Ef2); // HackDao WBNB

--- a/src/test/Harmony_multisig.sol
+++ b/src/test/Harmony_multisig.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.10;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     IERC20 usdt = IERC20(0xdAC17F958D2ee523a2206206994597C13D831ec7);
     MultiSig MultiSigWallet = MultiSig(payable(0x715CdDa5e9Ad30A0cEd14940F9997EE611496De6));

--- a/src/test/HarvestFinance_exp.sol
+++ b/src/test/HarvestFinance_exp.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.10;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     // CONTRACTS
     // Uniswap ETH/USDC LP (UNI-V2)

--- a/src/test/INUKO_exp.sol
+++ b/src/test/INUKO_exp.sol
@@ -44,7 +44,7 @@ interface Unitroller {
     function enterMarkets(address[] calldata vTokens) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 INUKO = IERC20(0xEa51801b8F5B88543DdaD3D1727400c15b209D8f);
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
     IERC20 WBNB = IERC20(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);

--- a/src/test/InverseFinance_exp.sol
+++ b/src/test/InverseFinance_exp.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 WBTC = IERC20(0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599);
     IERC20 WETH = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     USDT usdt = USDT(0xdAC17F958D2ee523a2206206994597C13D831ec7);

--- a/src/test/Kashi_exp.sol
+++ b/src/test/Kashi_exp.sol
@@ -50,7 +50,7 @@ interface CauldronMediumRiskV1 {
     ) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     BentoBoxV1 BentBox = BentoBoxV1(0xF5BCE5077908a1b7370B9ae04AdC565EBd643966);
     CauldronMediumRiskV1 Cauldron = CauldronMediumRiskV1(0xbb02A884621FB8F5BFd263A67F58B65df5b090f3);
     IERC20 xSUSHI = IERC20(0x8798249c2E607446EfB7Ad49eC89dD1865Ff4272);

--- a/src/test/LiFi_exp.sol
+++ b/src/test/LiFi_exp.sol
@@ -41,7 +41,7 @@ interface ILIFI {
     ) external payable;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     address from = address(0xC6f2bDE06967E04caAf4bF4E43717c3342680d76);
     address lifi = address(0x5A9Fd7c39a6C488E715437D7b1f3C823d5596eD1);
     address exploiter = address(0x878099F08131a18Fab6bB0b4Cfc6B6DAe54b177E);

--- a/src/test/MBC_ZZSH_exp.sol
+++ b/src/test/MBC_ZZSH_exp.sol
@@ -18,7 +18,7 @@ interface IZZSH is IERC20 {
     function swapAndLiquifyStepv1() external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
     IERC20 ETH = IERC20(0x2170Ed0880ac9A755fd29B2688956BD959F933F8);
     IMBC MBC = IMBC(0x4E87880A72f6896E7e0a635A5838fFc89b13bd17);

--- a/src/test/MUMUG_exp.sol
+++ b/src/test/MUMUG_exp.sol
@@ -14,7 +14,7 @@ interface MUBank {
     function mu_gold_bond(address stable, uint256 amount) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     MUBank Bank = MUBank(0x4aA679402c6afcE1E0F7Eb99cA4f09a30ce228ab);
     IERC20 MU = IERC20(0xD036414fa2BCBb802691491E323BFf1348C5F4Ba);
     IERC20 MUG = IERC20(0xF7ed17f0Fb2B7C9D3DDBc9F0679b2e1098993e81);

--- a/src/test/Meter_exp.sol
+++ b/src/test/Meter_exp.sol
@@ -14,7 +14,7 @@ interface SushiRouter {
     ) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     address attacker = 0x8d3d13cac607B7297Ff61A5E1E71072758AF4D01;
     address sushiSwapRouter = 0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506;

--- a/src/test/Midas_exp.sol
+++ b/src/test/Midas_exp.sol
@@ -42,7 +42,7 @@ contract LiquidateContract {
     }
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IBalancerVault balancer = IBalancerVault(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
     IAaveFlashloan aaveV3 = IAaveFlashloan(0x794a61358D6845594F94dc1DB02A252b5b4814aD);
     IAaveFlashloan aaveV2 = IAaveFlashloan(0x8dFf5E27EA6b7AC08EbFdf9eB090F32ee9a30fcf);

--- a/src/test/Mono_exp.t.sol
+++ b/src/test/Mono_exp.t.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     WETH9 WETH = WETH9(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     USDC usdc = USDC(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
     MonoToken mono = MonoToken(0x2920f7d6134f4669343e70122cA9b8f19Ef8fa5D);

--- a/src/test/MooCAKECTX_exp.sol
+++ b/src/test/MooCAKECTX_exp.sol
@@ -41,7 +41,7 @@ interface Unitroller {
     function enterMarkets(address[] calldata vTokens) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 WBNB = IERC20(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
     IERC20 CTK = IERC20(0xA8c2B8eec3d368C0253ad3dae65a5F2BBB89c929);
     IERC20 BUSD = IERC20(0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56);

--- a/src/test/MulticallWithoutCheck_exp.sol
+++ b/src/test/MulticallWithoutCheck_exp.sol
@@ -15,7 +15,7 @@ interface Target {
     function multicallWithoutCheck(Call[] memory calls) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     struct Call {
         address target;
         bytes callData;

--- a/src/test/N00d_exp.sol
+++ b/src/test/N00d_exp.sol
@@ -15,7 +15,7 @@ interface sushiBar {
     function leave(uint256) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC777 n00d = IERC777(0x2321537fd8EF4644BacDCEec54E5F35bf44311fA);
     Uni_Pair_V2 Pair = Uni_Pair_V2(0x5476DB8B72337d44A6724277083b1a927c82a389);
     IERC20 WETH = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);

--- a/src/test/NUM_exp.sol
+++ b/src/test/NUM_exp.sol
@@ -23,7 +23,7 @@ interface MultichainRouter {
     ) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 NUM = IERC20(0x3496B523e5C00a4b4150D6721320CdDb234c3079);
     IERC20 USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
     IERC20 WETH = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);

--- a/src/test/NXUSD_exp.sol
+++ b/src/test/NXUSD_exp.sol
@@ -32,7 +32,7 @@ interface ICauldronV2 {
     ) external payable returns (uint256, uint256);
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     ILendingPool aaveLendingPool = ILendingPool(0x794a61358D6845594F94dc1DB02A252b5b4814aD);
     Uni_Router_V2 Router = Uni_Router_V2(0x60aE616a2155Ee3d9A68541Ba4544862310933d4);
     Uni_Pair_V2 Pair = Uni_Pair_V2(0xf4003F4efBE8691B60249E6afbD307aBE7758adb);

--- a/src/test/Nimbus_exp.sol
+++ b/src/test/Nimbus_exp.sol
@@ -16,7 +16,7 @@ interface IERC20Custom {
     uint balance0Adjusted = balance0.mul(10000).sub(amount0In.mul(15));
     uint balance1Adjusted = balance1.mul(10000).sub(amount1In.mul(15));
     require(balance0Adjusted.mul(balance1Adjusted) >= uint(_reserve0).mul(_reserve1).mul(1000**2), 'Nimbus: K');*/
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     address public pair = 0xc0A6B8c534FaD86dF8FA1AbB17084A70F86EDDc1;
     address public usdt = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);

--- a/src/test/NovaExchange_exp.sol
+++ b/src/test/NovaExchange_exp.sol
@@ -18,7 +18,7 @@ interface INovaExchange {
     function approve(address spender, uint256 value) external returns (bool);
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     INovaExchange novaContract = INovaExchange(0xB5B27564D05Db32CF4F25813D35b6E6de9210941);
     address attacker = 0xCBF184b8156e1271449CFb42A7D0556A8DCFEf72;

--- a/src/test/Novo_exp.sol
+++ b/src/test/Novo_exp.sol
@@ -17,7 +17,7 @@ interface INOVOLP {
     function sync() external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IPancakePair PancakePair = IPancakePair(0xEeBc161437FA948AAb99383142564160c92D2974);
     IPancakeRouter PancakeRouter = IPancakeRouter(payable(0x10ED43C718714eb63d5aA57B78B54704E256024E));
     IWBNB wbnb = IWBNB(payable(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c));

--- a/src/test/NowSwap_exp.sol
+++ b/src/test/NowSwap_exp.sol
@@ -12,7 +12,7 @@ interface IERC20Custom {
     Vulnerable contract: https://etherscan.io/address/0xa14660a33cc608b902f5bb49c8213bd4c8a4f4ca#code unverified contract
     root cause: inconsistent value in the code, 10000 vs 1000.
     Attacker contract: 0x5676e585bf16387bc159fd4f82416434cda5f1a3*/
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     address public pair = 0xA0Ff0e694275023f4986dC3CA12A6eb5D6056C62; //NWETH/NBU
     address public nbu = 0xEB58343b36C7528F23CAAe63a150240241310049;
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);

--- a/src/test/Omni_exp.sol
+++ b/src/test/Omni_exp.sol
@@ -6,7 +6,7 @@ import "./interface.sol";
 
 // Credit: SupremacyCA, the poc rewritten from SupremacyCA.
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 WETH = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     IERC20 doodle = IERC20(0x2F131C4DAd4Be81683ABb966b4DE05a549144443);
     IDOODLENFTXVault doodleVault = IDOODLENFTXVault(0x2F131C4DAd4Be81683ABb966b4DE05a549144443);

--- a/src/test/OneRing_exp.sol
+++ b/src/test/OneRing_exp.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.10;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IUniswapV2Pair pair = IUniswapV2Pair(0xbcab7d083Cf6a01e0DdA9ed7F8a02b47d125e682);
     IERC20 usdc = IERC20(0x04068DA6C83AFCFA0e13ba15A6696662335D5B75);
     IOneRingVault vault = IOneRingVault(0x4e332D616b5bA1eDFd87c899E534D996c336a2FC);

--- a/src/test/Optimism_exp.sol
+++ b/src/test/Optimism_exp.sol
@@ -8,7 +8,7 @@ interface ProxyFactory {
     function createProxy(address masterCopy, bytes calldata data) external returns (address payable proxy);
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     ProxyFactory proxy = ProxyFactory(0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B);
     address public childcontract;
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);

--- a/src/test/Opyn.exp.sol
+++ b/src/test/Opyn.exp.sol
@@ -11,7 +11,7 @@ https://medium.com/opyn/opyn-eth-put-exploit-post-mortem-1a009e3347a8
 @Transaction
 0x56de6c4bd906ee0c067a332e64966db8b1e866c7965c044163a503de6ee6552a*/
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IOpyn opyn = IOpyn(0x951D51bAeFb72319d9FBE941E1615938d89ABfe2);
 
     address attacker = 0xe7870231992Ab4b1A01814FA0A599115FE94203f;

--- a/src/test/Overnight_exp.sol
+++ b/src/test/Overnight_exp.sol
@@ -100,7 +100,7 @@ interface SicleRouter {
     ) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     JoeRouter Router = JoeRouter(0x60aE616a2155Ee3d9A68541Ba4544862310933d4);
     SicleRouter sicleRouter = SicleRouter(0xC7f372c62238f6a5b79136A9e5D16A2FD7A3f0F5);
     USDPlus USDplus = USDPlus(0x73cb180bf0521828d8849bc8CF2B920918e23032);

--- a/src/test/PAID_exp.sol
+++ b/src/test/PAID_exp.sol
@@ -16,7 +16,7 @@ interface IPaid {
     function balanceOf(address account) external view returns (uint256);
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     // FakeToken FakeTokenContract;
     IPaid PAID = IPaid(0x8c8687fC965593DFb2F0b4EAeFD55E9D8df348df);
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);

--- a/src/test/PLTD_exp.sol
+++ b/src/test/PLTD_exp.sol
@@ -9,7 +9,7 @@ import "./interface.sol";
 // TX
 // https://bscscan.com/tx/0x8385625e9d8011f4ad5d023d64dc7985f0315b6a4be37424c7212fe4c10dafe0
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
     IERC20 PLTD = IERC20(0x29b2525e11BC0B0E9E59f705F318601eA6756645);
     Uni_Pair_V2 Pair = Uni_Pair_V2(0x4397C76088db8f16C15455eB943Dd11F2DF56545);

--- a/src/test/PancakeBunny_exp.sol
+++ b/src/test/PancakeBunny_exp.sol
@@ -21,7 +21,7 @@ import "./interface.sol";
  * https://www.newsbtc.com/news/company/bsc-flash-loan-attack-pancakebunny/
  */
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     address WBNB = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c;
     address USDT = 0x55d398326f99059fF775485246999027B3197955;

--- a/src/test/PancakeHunny_exp.sol
+++ b/src/test/PancakeHunny_exp.sol
@@ -22,7 +22,7 @@ interface CakeFlipVault {
     function rewards(address) external view returns (uint256);
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     IPancakeRouter pancakeRouter = IPancakeRouter(payable(0x10ED43C718714eb63d5aA57B78B54704E256024E));
 

--- a/src/test/Paraluni_exp.sol
+++ b/src/test/Paraluni_exp.sol
@@ -41,7 +41,7 @@ contract EvilToken {
     }
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IPancakePair pair = IPancakePair(0x7EFaEf62fDdCCa950418312c6C91Aef321375A00);
     IERC20 usdt = IERC20(0x55d398326f99059fF775485246999027B3197955);
     IERC20 busd = IERC20(0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56);

--- a/src/test/Parity_kill.sol
+++ b/src/test/Parity_kill.sol
@@ -12,7 +12,7 @@ interface parity {
     function initWallet(address[] memory _owners, uint256 _required, uint256 _daylimit) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     parity WalletLibrary = parity(payable(0x863DF6BFa4469f3ead0bE8f9F2AAE51c91A907b4));
 
     address[] public owner;

--- a/src/test/PolyNetwork/PolyNetwork_exp.sol
+++ b/src/test/PolyNetwork/PolyNetwork_exp.sol
@@ -34,7 +34,7 @@ interface IEthCrossChainData {
     function getEthTxHash(uint256 ethTxHashIndex) external view returns (bytes32);
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     struct Header {
         uint32 version;
         uint64 chainId;

--- a/src/test/QTN_exp.sol
+++ b/src/test/QTN_exp.sol
@@ -18,7 +18,7 @@ contract QTNContract {
     }
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 QTN = IERC20(0xC9fa8F4CFd11559b50c5C7F6672B9eEa2757e1bd);
     IERC20 WETH = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     Uni_Router_V2 Router = Uni_Router_V2(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);

--- a/src/test/Qubit_exp.sol
+++ b/src/test/Qubit_exp.sol
@@ -15,7 +15,7 @@ interface IQBridgeHandler {
     function deposit(bytes32 resourceID, address depositer, bytes calldata data) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     address attacker = 0xD01Ae1A708614948B2B5e0B7AB5be6AFA01325c7;
     address QBridge = 0x20E5E35ba29dC3B540a1aee781D0814D5c77Bce6;

--- a/src/test/Quixotic_exp.sol
+++ b/src/test/Quixotic_exp.sol
@@ -20,7 +20,7 @@ interface Quixotic {
     ) external payable;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     IERC20 op = IERC20(0x4200000000000000000000000000000000000042);
     Quixotic quixotic = Quixotic(0x065e8A87b8F11aED6fAcf9447aBe5E8C5D7502b6);

--- a/src/test/RADT_exp.sol
+++ b/src/test/RADT_exp.sol
@@ -13,7 +13,7 @@ interface IDODO {
     function _BASE_TOKEN_() external view returns (address);
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
     IERC20 RADT = IERC20(0xDC8Cb92AA6FC7277E3EC32e3f00ad7b8437AE883);
     Uni_Pair_V2 pair = Uni_Pair_V2(0xaF8fb60f310DCd8E488e4fa10C48907B7abf115e);

--- a/src/test/RFB_exp.sol
+++ b/src/test/RFB_exp.sol
@@ -9,7 +9,7 @@ import "./interface.sol";
 // @TX
 // https://bscscan.com/tx/0xcc8fdb3c6af8bb9dfd87e913b743a13bbf138a143c27e0f387037887d28e3c7a
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 RFB = IERC20(0x26f1457f067bF26881F311833391b52cA871a4b5);
     IWBNB WBNB = IWBNB(payable(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c));
     Uni_Router_V2 Router = Uni_Router_V2(0x10ED43C718714eb63d5aA57B78B54704E256024E);

--- a/src/test/RL_exp.sol
+++ b/src/test/RL_exp.sol
@@ -35,7 +35,7 @@ contract AirDropRewardContract {
     }
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
     IERC20 RL = IERC20(0x4bBfae575Dd47BCFD5770AB4bC54Eb83DB088888);
     RLLpIncentive RLL = RLLpIncentive(0x335ddcE3f07b0bdaFc03F56c1b30D3b269366666);

--- a/src/test/RariCapital_exp.sol
+++ b/src/test/RariCapital_exp.sol
@@ -14,7 +14,7 @@ interface Bank {
     function work(uint256 id, address goblin, uint256 loan, uint256 maxReturn, bytes calldata data) external payable;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     Bank vault = Bank(0x67B66C99D3Eb37Fa76Aa3Ed1ff33E8e39F0b9c7A);
     IERC20 fakeToken = IERC20(payable(0x2f755e8980f0c2E81681D82CCCd1a4BD5b4D5D46));
     address attacker = address(0xCB36b1ee0Af68Dce5578a487fF2Da81282512233);

--- a/src/test/Rari_exp.t.sol
+++ b/src/test/Rari_exp.t.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 usdc = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
 
     ICEtherDelegate fETH_127 = ICEtherDelegate(payable(0x26267e41CeCa7C8E0f143554Af707336f27Fa051));

--- a/src/test/RedactedCartel_exp.sol
+++ b/src/test/RedactedCartel_exp.sol
@@ -12,7 +12,7 @@ The vulnerability would have allowed a malicious attacker to assign a user’s a
 
 a faulty implementation of standard transferFrom() ERC-20 function in wxBTRFLY token.
 */
-contract RedactedCartelExploit is DSTest {
+contract RedactedCartelExploit is Test {
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     IRedactedCartelSafeERC20 wxBTRFLY = IRedactedCartelSafeERC20(0x186E55C0BebD2f69348d94C4A27556d93C5Bd36C);
 

--- a/src/test/Revest_exp.sol
+++ b/src/test/Revest_exp.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IUniswapV2Pair pair = IUniswapV2Pair(0xbC2C5392b0B841832bEC8b9C30747BADdA7b70ca);
     IERC20 rena = IERC20(0x56de8BC61346321D4F2211e3aC3c0A7F00dB9b76);
     IRevest revest = IRevest(0x2320A28f52334d62622cc2EaFa15DE55F9987eD9);

--- a/src/test/Rikkei_exp.sol
+++ b/src/test/Rikkei_exp.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 usdc = IERC20(0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d);
     IRToken rbnb = IRToken(0x157822aC5fa0Efe98daa4b0A55450f4a182C10cA);
     IRToken rusdc = IRToken(0x916e87d16B2F3E097B9A6375DC7393cf3B5C11f5);

--- a/src/test/RoeFinance_exp.sol
+++ b/src/test/RoeFinance_exp.sol
@@ -24,7 +24,7 @@ interface vdWBTC_USDC_LP {
     function approveDelegation(address delegatee, uint256 amount) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IBalancerVault balancer = IBalancerVault(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
     ROE roe = ROE(0x5F360c6b7B25DfBfA4F10039ea0F7ecfB9B02E60);
     Uni_Pair_V2 Pair = Uni_Pair_V2(0x004375Dff511095CC5A197A54140a24eFEF3A416);

--- a/src/test/Ronin_exp.sol
+++ b/src/test/Ronin_exp.sol
@@ -15,7 +15,7 @@ interface IRoninBridge {
     ) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     address attacker = 0x098B716B8Aaf21512996dC57EB0615e2383E2f96;
     address roninBridge = 0x1A2a1c938CE3eC39b6D47113c7955bAa9DD454F2;
     address WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;

--- a/src/test/Rubic_exp.sol
+++ b/src/test/Rubic_exp.sol
@@ -44,7 +44,7 @@ interface RubicProxy2 {
     ) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
     RubicProxy1 Rubic1 = RubicProxy1(0x3335A88bb18fD3b6824b59Af62b50CE494143333);
     RubicProxy2 Rubic2 = RubicProxy2(0x33388CF69e032C6f60A420b37E44b1F5443d3333);

--- a/src/test/SDAO_exp.sol
+++ b/src/test/SDAO_exp.sol
@@ -22,7 +22,7 @@ interface sDAO is IERC20 {
     function getReward() external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
     sDAO SDAO = sDAO(0x6666625Ab26131B490E7015333F97306F05Bf816);
     Uni_Router_V2 Router = Uni_Router_V2(0x10ED43C718714eb63d5aA57B78B54704E256024E);

--- a/src/test/SEAMAN_exp.sol
+++ b/src/test/SEAMAN_exp.sol
@@ -11,7 +11,7 @@ import "./interface.sol";
 // @TX
 // https://bscscan.com/tx/0x6f1af27d08b10caa7e96ec3d580bf39e29fd5ece00abda7d8955715403bf34a8
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
     IERC20 SEAMAN = IERC20(0x6bc9b4976ba6f8C9574326375204eE469993D038);
     IERC20 GVC = IERC20(0xDB95FBc5532eEb43DeEd56c8dc050c930e31017e);

--- a/src/test/SVT_exp.sol
+++ b/src/test/SVT_exp.sol
@@ -14,7 +14,7 @@ interface ISVTpool {
     function sell(uint256 amount) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 BUSD = IERC20(0x55d398326f99059fF775485246999027B3197955);
     IERC20 SVT = IERC20(0x657334B4FF7bDC4143941B1F94301f37659c6281);
     ISVTpool pool = ISVTpool(0x2120F8F305347b6aA5E5dBB347230a8234EB3379);

--- a/src/test/Saddle_exp.sol
+++ b/src/test/Saddle_exp.sol
@@ -16,7 +16,7 @@ interface ISaddle {
     function swap(uint8 i, uint8 j, uint256 dx, uint256 min_dy, uint256 deadline) external returns (uint256);
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     address private constant eulerLoans = 0x07df2ad9878F8797B4055230bbAE5C808b8259b3;
     address private constant usdc = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     address private constant susd = 0x57Ab1ec28D129707052df4dF418D58a2D46d5f51;

--- a/src/test/SafeDollar_exp.sol
+++ b/src/test/SafeDollar_exp.sol
@@ -67,7 +67,7 @@ contract depositToken {
     }
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 SDO = IERC20(0x86BC05a6f65efdaDa08528Ec66603Aef175D967f);
     IERC20 WMATIC = IERC20(0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270);
     IERC20 PLX = IERC20(0x7A5dc8A09c831251026302C93A778748dd48b4DF);

--- a/src/test/Sandbox_exp.sol
+++ b/src/test/Sandbox_exp.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     ILand Land = ILand(0x50f5474724e0Ee42D9a4e711ccFB275809Fd6d4a);
     address victim = 0x9cfA73B8d300Ec5Bf204e4de4A58e5ee6B7dC93C;
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);

--- a/src/test/Shadowfi_exp.sol
+++ b/src/test/Shadowfi_exp.sol
@@ -13,7 +13,7 @@ interface IPair {
     function sync() external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 WBNB = IERC20(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
     Uni_Router_V2 Router = Uni_Router_V2(0x10ED43C718714eb63d5aA57B78B54704E256024E);
     ISDF SDF = ISDF(0x10bc28d2810dD462E16facfF18f78783e859351b);

--- a/src/test/SheepFarm_exp.sol
+++ b/src/test/SheepFarm_exp.sol
@@ -18,7 +18,7 @@ interface SheepFram {
     function sellVillage() external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     SheepFram sheepFram = SheepFram(0x4726010da871f4b57b5031E3EA48Bde961F122aA);
     address neighbor = 0x14598f3a9f3042097486DC58C65780Daf3e3acFB;
 

--- a/src/test/Snood_poc.t.sol
+++ b/src/test/Snood_poc.t.sol
@@ -12,7 +12,7 @@ interface IUNIPAIR is IERC20 {
     function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes calldata data) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 SNOOD = IERC20(0xD45740aB9ec920bEdBD9BAb2E863519E59731941);
     IERC20 WETH = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
 

--- a/src/test/Sushimiso_exp.sol
+++ b/src/test/Sushimiso_exp.sol
@@ -17,7 +17,7 @@ interface IDutchAuction {
     ) external payable returns (bool[] memory successes, bytes[] memory results);
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IDutchAuction DutchAuction = IDutchAuction(0x4c4564a1FE775D97297F9e3Dc2e762e0Ed5Dda0e);
     IERC20 WETH = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     bytes[] public data;

--- a/src/test/THB_exp.sol
+++ b/src/test/THB_exp.sol
@@ -36,7 +36,7 @@ interface HouseWallet {
     ) external payable;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     HouseWallet houseWallet = HouseWallet(0xae191Ca19F0f8E21d754c6CAb99107eD62B6fe53);
     uint256 randomNumber = 12_345_678_000_000_000_000_000_000;
 

--- a/src/test/TIFI_exp.sol
+++ b/src/test/TIFI_exp.sol
@@ -14,7 +14,7 @@ interface TIFIFinance {
     function borrow(address qToken, uint256 amount) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     TIFIFinance TIFI = TIFIFinance(0x8A6F7834A9d60090668F5db33FEC353a7Fb4704B);
     Uni_Router_V2 Router = Uni_Router_V2(0x10ED43C718714eb63d5aA57B78B54704E256024E);
     Uni_Router_V2 TIFIRouter = Uni_Router_V2(0xC8595392B8ca616A226dcE8F69D9E0c7D4C81FE4);

--- a/src/test/TreasureDAO_exp.sol
+++ b/src/test/TreasureDAO_exp.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.10;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     ITreasureMarketplaceBuyer itreasure = ITreasureMarketplaceBuyer(0x812cdA2181ed7c45a35a691E0C85E231D218E273);
     IERC721 iSmolBrain = IERC721(0x6325439389E0797Ab35752B4F43a14C004f22A9c);
     uint256 tokenId = 3557;

--- a/src/test/UEarnPool_exp.sol
+++ b/src/test/UEarnPool_exp.sol
@@ -51,7 +51,7 @@ contract claimReward {
     }
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     UEarnPool Pool = UEarnPool(0x02D841B976298DCd37ed6cC59f75D9Dd39A3690c);
     Uni_Pair_V2 Pair = Uni_Pair_V2(0x7EFaEf62fDdCCa950418312c6C91Aef321375A00);
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);

--- a/src/test/UFDao_exp.sol
+++ b/src/test/UFDao_exp.sol
@@ -22,7 +22,7 @@ interface IUFT is IERC20 {
     ) external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     Uni_Router_V2 Router = Uni_Router_V2(0x10ED43C718714eb63d5aA57B78B54704E256024E);
     SHOP shop = SHOP(0xCA49EcF7e7bb9bBc9D1d295384663F6BA5c0e366);
     IUFT UFT = IUFT(0xf887A2DaC0DD432997C970BCE597A94EaD4A8c25);

--- a/src/test/ULME_exp.sol
+++ b/src/test/ULME_exp.sol
@@ -26,7 +26,7 @@ IULME constant ULME = IULME(0xAE975a25646E6eB859615d0A147B909c13D31FEd);
 address constant dodo1 = 0xD7B7218D778338Ea05f5Ecce82f86D365E25dBCE;
 address constant dodo2 = 0x9ad32e3054268B849b84a8dBcC7c8f7c52E4e69A;
 
-contract Attacker is DSTest {
+contract Attacker is Test {
     IERC20 constant USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
 
     uint256 dodo1Balance;

--- a/src/test/VTF_exp.sol
+++ b/src/test/VTF_exp.sol
@@ -39,7 +39,7 @@ contract claimReward {
     }
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     address constant dodo = 0x26d0c625e5F5D6de034495fbDe1F6e9377185618;
     IVTF VTF = IVTF(0xc6548caF18e20F88cC437a52B6D388b0D54d830D);
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);

--- a/src/test/ValueDefi_exp.sol
+++ b/src/test/ValueDefi_exp.sol
@@ -22,7 +22,7 @@ interface AlpacaWBNBVault {
     ) external payable;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     AlpacaWBNBVault vault = AlpacaWBNBVault(0xd7D069493685A581d27824Fc46EdA46B7EfC0063);
     IWBNB wbnb = IWBNB(payable(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c));
     IERC20 vSafeVaultWBNB = IERC20(payable(0xD4BBF439d3EAb5155Ca7c0537E583088fB4CFCe8));

--- a/src/test/Visor_exp.t.sol
+++ b/src/test/Visor_exp.t.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IRewardsHypervisor irrewards = IRewardsHypervisor(0xC9f27A50f82571C1C8423A42970613b8dBDA14ef);
     IvVISR visr = IvVISR(0x3a84aD5d16aDBE566BAA6b3DafE39Db3D5E261E5);
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);

--- a/src/test/WaultFinance_exp.sol
+++ b/src/test/WaultFinance_exp.sol
@@ -15,7 +15,7 @@ interface WUSDMASTER {
     function maxStakeAmount() external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 WUSD = IERC20(0x3fF997eAeA488A082fb7Efc8e6B9951990D0c3aB);
     IERC20 BUSD = IERC20(0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56);
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);

--- a/src/test/Wdoge_exp.sol
+++ b/src/test/Wdoge_exp.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.10;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IWBNB wbnb = IWBNB(payable(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c));
     IERC20 busd = IERC20(0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56);
     IERC20 wdoge = IERC20(0x46bA8a59f4863Bd20a066Fd985B163235425B5F9);

--- a/src/test/XCarnival.exp.sol
+++ b/src/test/XCarnival.exp.sol
@@ -59,7 +59,7 @@ interface INothing {
 }
 
 /* Contract: 0x2d6e070af9574d07ef17ccd5748590a86690d175 */
-contract payloadContract is DSTest {
+contract payloadContract is Test {
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     uint256 orderId = 0;
@@ -106,7 +106,7 @@ contract payloadContract is DSTest {
 }
 
 /* Contract: 0xf70f691d30ce23786cfb3a1522cfd76d159aca8d */
-contract mainAttackContract is DSTest {
+contract mainAttackContract is Test {
     address payable[33] public payloads;
     address attacker = 0xb7CBB4d43F1e08327A90B32A8417688C9D0B800a;
     IBAYC BAYC = IBAYC(0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D);

--- a/src/test/XST02_exp.sol
+++ b/src/test/XST02_exp.sol
@@ -9,7 +9,7 @@ import "./interface.sol";
 // XST Logic Contract Address: https://etherscan.io/address/0xb276647e70cb3b81a1ca302cf8de280ff0ce5799#code
 // https://tools.blocksec.com/tx/eth/0x873f7c77d5489c1990f701e9bb312c103c5ebcdcf0a472db726730814bfd55f3
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 XST = IERC20(0x91383A15C391c142b80045D8b4730C1c37ac0378);
     IERC20 WETH = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     Uni_Pair_V2 Pair1 = Uni_Pair_V2(0x0d4a11d5EEaaC28EC3F61d100daF4d40471f1852); // WETH USDT

--- a/src/test/XSURGE_exp.t.sol
+++ b/src/test/XSURGE_exp.t.sol
@@ -19,7 +19,7 @@ interface Token {
     function transfer(address recipient, uint256 amount) external returns (bool);
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IpancakePair ipancake = IpancakePair(0x0eD7e52944161450477ee417DE9Cd3a859b14fD0);
     WBNB wbnb = WBNB(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
     Surge surge = Surge(0xE1E1Aa58983F6b8eE8E4eCD206ceA6578F036c21);

--- a/src/test/Yyds_exp.sol
+++ b/src/test/Yyds_exp.sol
@@ -13,7 +13,7 @@ interface TargetWithdraw {
     function withdrawReturnAmountByReferral() external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 WBNB = IERC20(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
     IERC20 USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
     IERC20 YYDS = IERC20(0xB19463ad610ea472a886d77a8ca4b983E4fAf245);

--- a/src/test/ZABU_exp.sol
+++ b/src/test/ZABU_exp.sol
@@ -58,7 +58,7 @@ contract depositToken {
     }
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IERC20 ZABU = IERC20(0xDd453dBD253fA4E5e745047d93667Ce9DA93bbCF);
     IERC20 WAVAX = IERC20(0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7);
     IERC20 SPORE = IERC20(0x6e7f5C0b9f4432716bDd0a77a3601291b9D9e985);

--- a/src/test/Zeed_exp.sol
+++ b/src/test/Zeed_exp.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.10;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IPancakeRouter pancakeRouter = IPancakeRouter(payable(0x6CD71A07E72C514f5d511651F6808c6395353968));
     IPancakePair usdtYeedHoSwapPair = IPancakePair(0x33d5e574Bd1EBf3Ceb693319C2e276DaBE388399);
     IPancakePair usdtYeedPair = IPancakePair(0xA7741d6b60A64b2AaE8b52186adeA77b1ca05054);

--- a/src/test/ZoomproFinance_exp.sol
+++ b/src/test/ZoomproFinance_exp.sol
@@ -26,7 +26,7 @@ interface IUSD {
     function sync() external;
 }
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     IPancakePair PancakePair = IPancakePair(0x7EFaEf62fDdCCa950418312c6C91Aef321375A00); // KIMO/WBNB pair
     address private usdt = 0x55d398326f99059fF775485246999027B3197955;
     address private swap = 0x5a9846062524631C01ec11684539623DAb1Fae58;

--- a/src/test/cftoken_exp.sol
+++ b/src/test/cftoken_exp.sol
@@ -26,7 +26,7 @@ import "./interface.sol";
 
 // Test result: ok. 1 passed; 0 failed; finished in 9.72s%
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     address private cftoken = 0x8B7218CF6Ac641382D7C723dE8aA173e98a80196;
     address private cfpair = 0x7FdC0D8857c6D90FD79E22511baf059c0c71BF8b;
     CheatCodes cheats = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);

--- a/src/test/deus_exp.sol
+++ b/src/test/deus_exp.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.10;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     CheatCodes cheat = CheatCodes(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     IBaseV1Router01 router = IBaseV1Router01(0xa38cd27185a464914D3046f0AB9d43356B34829D);

--- a/src/test/dodo_flashloan_exp.sol
+++ b/src/test/dodo_flashloan_exp.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "forge-std/Test.sol";
 import "./interface.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     uint256 wCRES_amount = 130_000_000_000_000_000_000_000;
 
     uint256 usdt_amount = 1_100_000_000_000;

--- a/src/test/paraspace_exp.sol
+++ b/src/test/paraspace_exp.sol
@@ -9,7 +9,7 @@ import "./interface.sol";
 // @TX
 // https://etherscan.io/tx/0xe3f0d14cfb6076cabdc9057001c3fafe28767a192e88005bc37bd7d385a1116a
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     address _pcAPE = 0xDDDe38696FBe5d11497D72d8801F651642d62353;
     address _vDebtUSDC = 0x1B36ad30F6866716FF08EB599597D8CE7607571d;
     address _vDebtwstETH = 0xCA76D6D905b08e3224945bFA0340E92CCbbE5171;


### PR DESCRIPTION
As the package `ds-test` was removed in https://github.com/foundry-rs/forge-std/pull/503, so the `DSTest` is unavailable anymore, use `Test` instead.