### PR TITLE
fix: update rpc endpoint path

### DIFF
--- a/add_new_entry.py
+++ b/add_new_entry.py
@@ -6,14 +6,14 @@ import toml
 def parse_foundry_toml():
     with open("foundry.toml", "r") as toml_file:
         config = toml.load(toml_file)
-        rpc_endpoints = config.get("profile", {}).get("default", {}).get("rpc_endpoints", {})
+        rpc_endpoints = config.get("rpc_endpoints", {})
     return rpc_endpoints
 
 def update_foundry_toml(rpc_endpoints):
     with open("foundry.toml", "r") as toml_file:
         config = toml.load(toml_file)
 
-    config["profile"]["default"]["rpc_endpoints"] = rpc_endpoints
+    config["rpc_endpoints"] = rpc_endpoints
 
     with open("foundry.toml", "w") as toml_file:
         toml.dump(config, toml_file)


### PR DESCRIPTION
Currently, we are unable to add new entry, since we can not select the corresponding network.

![Screenshot 2024-04-29 at 12 55 19 PM](https://github.com/SunWeb3Sec/DeFiHackLabs/assets/72684086/5b96a65b-7a0b-496e-841e-7c677e7602d5)

The network configuration in `foundry.toml` is slightly changed in this [commit](https://github.com/SunWeb3Sec/DeFiHackLabs/commit/810c53093cee8db57c03ade4952f7efa65c542df), but it does not update the path in `add_new_entry.py` file.

The original network configuration, `rpc_endpoints`, was previously a subcategory under the `profile.default` category in `foundry.toml`, but it is now separate as an independent category, `rpc_endpoints`.

After this fix, you should be able to add new entries.

![Screenshot 2024-04-29 at 12 55 55 PM](https://github.com/SunWeb3Sec/DeFiHackLabs/assets/72684086/a221a7dc-c9df-4078-80ac-ee7ab5b80f22)


