### PR TITLE
fix: flashswap not printing stack trace

### DIFF
--- a/academy/onchain_debug/02_warmup/en/readme.md
+++ b/academy/onchain_debug/02_warmup/en/readme.md
@@ -115,7 +115,7 @@ Here we use Foundry to simulate operations - how to use flash loans on Uniswap. 
 - [Sample Code](https://github.com/SunWeb3Sec/DeFiLabs/blob/main/src/test/Uniswapv2_flashswap.sol) Reference, execute the following command:
 
 ```sh
-forge test --contracts ./src/test/Uniswapv2_flashswap.sol -vv
+forge test --contracts ./src/test/Uniswapv2_flashswap.sol -vvvv
 ```
 
 ![圖片](https://user-images.githubusercontent.com/52526645/211125357-695c3fd0-4a56-4a70-9c98-80bac65586b8.png)

--- a/academy/onchain_debug/02_warmup/ko/readme.md
+++ b/academy/onchain_debug/02_warmup/ko/readme.md
@@ -115,7 +115,7 @@ forge test --contracts ./src/test/Uniswapv2.sol -vvvv
 - [샘플 코드](https://github.com/SunWeb3Sec/DeFiLabs/blob/main/src/test/Uniswapv2_flashswap.sol)를 참조하여, 다음 명령을 실행합니다.
 
 ```sh
-forge test --contracts ./src/test/Uniswapv2_flashswap.sol -vv
+forge test --contracts ./src/test/Uniswapv2_flashswap.sol -vvvv
 ```
 
 ![圖片](https://user-images.githubusercontent.com/52526645/211125357-695c3fd0-4a56-4a70-9c98-80bac65586b8.png)

--- a/academy/onchain_debug/02_warmup/readme.md
+++ b/academy/onchain_debug/02_warmup/readme.md
@@ -101,7 +101,7 @@ ERC-20 Tokens Transferred: 用戶 A 轉入 3,524,968.44 USDT 到 Curve 3 pool，
 
 [範例程式碼](https://github.com/SunWeb3Sec/DeFiLabs/blob/main/src/test/Uniswapv2_flashswap.sol)參考，執行以下指令
 ```sh
-forge test --contracts ./src/test/Uniswapv2_flashswap.sol -vv
+forge test --contracts ./src/test/Uniswapv2_flashswap.sol -vvvv
 ```
 ![圖片](https://user-images.githubusercontent.com/52526645/211125357-695c3fd0-4a56-4a70-9c98-80bac65586b8.png)
 


### PR DESCRIPTION
`forge test --contracts ./src/test/Uniswapv2_flashswap.sol -vv`
It only prints the following information and does not print the call stack, which can be confusing for beginners.
```
Ran 1 test for src/test/Uniswapv3_twap.sol:UniV3TWAPTest
[PASS] testGetTWATick() (gas: 28497)
Logs:
  Pool: 0x5777d92f208679DB4b9778590Fa3CAB3aC9e2168
  Time window: 600 seconds

  Price * 2^96 = 79228371980132557
  Price: https://www.wolframalpha.com/input?i=x+*+25E96+3D+79228371980132557

Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 3.24s (1.99s CPU time)

Ran 1 test suite in 3.26s (3.24s CPU time): 1 tests passed, 0 failed, 0 skipped (1 total tests)
~/DeFiLabs # forge test --contracts ./src/test/Uniswapv2.sol -vvvv
[⠊] Compiling...
[⠑] Compiling 10 files with Solc 0.8.10
[⠘] Solc 0.8.10 finished in 648.29ms
Compiler run successful!
```