### PR TITLE
Report and fix display and link issues

### DIFF
--- a/past/2022/README.md
+++ b/past/2022/README.md
@@ -3017,12 +3017,12 @@ Testing
 
 ```sh
 Solana TBD
-forge test --contracts ./src/test/2022-02/meter_exp.sol -vv
+forge test --contracts ./src/test/2022-02/Meter_exp.sol -vv
 ```
 
 #### Contract
 
-[meter_exp.sol](../../src/test/2022-02/meter_exp.sol)
+[Meter_exp.sol](../../src/test/2022-02/Meter_exp.sol)
 
 #### Link reference
 

--- a/past/2024/README.md
+++ b/past/2024/README.md
@@ -2635,7 +2635,7 @@ forge test --match-contract Bmizapper_exp -vvv
 
 #### Contract
 
-[BmiZapper_exp.sol](../../src/test/2024-01/BmiZapper_exp.sol)
+[BmiZapper_exp.sol](../../src/test/2024-01/Bmizapper_exp.sol)
 
 #### Link reference
 

--- a/past/2024/README.md
+++ b/past/2024/README.md
@@ -802,7 +802,7 @@ forge test --match-contract INcufi_exp -vvv
 
 #### Contract
 
-[INcufi_exp.sol](../../src/test/2024-06/Incufi_exp.sol)
+[INcufi_exp.sol](../../src/test/2024-06/INcufi_exp.sol)
 
 ### Link reference
 


### PR DESCRIPTION
I found some typo in the [Incident Explorer](https://defihacklabs.io/explorer/index.html) and this repo

1. **Life Protocol** and **ImpermaxV3**: (Explorer)

   * The `loss` values are exactly the same, and they don’t match what's written in the PoC.

2. **Sturdy Finance** and **MahaLend**: (Explorer)

   * Both have PoC files, but they’re not showing up in the explorer.

3. **BmiZapper**, **INcufi**, **Meter**: (Explorer + Github)

   * The links are wrong (also incorrect in the repo).
   * I’ve fixed these in this PR.

I found these issues while doing related research. Thanks for maintaining such a valuable resource.