### PR TITLE
Typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,11 +239,11 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 [20240902 Pythia](past/2024/README.md#20240902-pythia---logic-flaw)
 
+[20240828 AAVE](past/2024/README.md#20240828-aave---arbitrary-call-error)
+
 [20240816 Zenterest](past/2024/README.md#20240816-Zenterest---price-out-of-date)
 
 [20240816 OMPxContract](past/2024/README.md#20240816-ompx-contract---flashloan)
-
-[20240828 AAVE](past/2024/README.md#20240828-aave---arbitrary-call-error)
 
 [20240814 YodlRouter](past/2024/README.md#20240814-yodlrouter---arbitrary-call)
 
@@ -1327,6 +1327,23 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 ### List of DeFi Hacks & POCs
 
+### 20250816 d3xai - Price Manipulation
+
+### Lost: 190 BNB
+
+```sh
+forge test --contracts ./src/test/2025-08/d3xai_exp.sol -vvv
+```
+#### Contract
+
+[d3xai_exp.sol](src/test/2025-08/d3xai_exp.sol)
+
+### Link reference
+
+https://x.com/suplabsyi/status/1956695597546893598
+
+---
+
 ### 20250815 PDZ - Price Manipulation
 
 ### Lost: 3.3 BNB
@@ -1342,23 +1359,6 @@ forge test --contracts ./src/test/2025-08/PDZ_exp.sol -vvv
 ### Link reference
 
 https://x.com/tikkalaresearch/status/1957500585965678828
-
----
-
-### 20250816 d3xai - Price Manipulation
-
-### Lost: 190 BNB
-
-```sh
-forge test --contracts ./src/test/2025-08/d3xai_exp.sol -vvv
-```
-#### Contract
-
-[d3xai_exp.sol](src/test/2025-08/d3xai_exp.sol)
-
-### Link reference
-
-https://x.com/suplabsyi/status/1956695597546893598
 
 ---
 
@@ -1584,7 +1584,7 @@ https://x.com/ResupplyFi/status/1938927974272938420
 forge test --contracts ./src/test/2025-06/Gangsterfinance.sol -vvv --evm-version shanghai
 ```
 #### Contract
-[Gangsterfinance](src/test/2025-06/Gangsterfinance.sol)
+[Gangsterfinance](src/test/2025-06/Gangsterfinance_exp.sol)
 ### Link reference
 
 https://t.me/defimon_alerts/1323
@@ -1661,7 +1661,7 @@ https://x.com/TenArmorAlert/status/1926587721885040686
 forge test --contracts ./src/test/2025-05/KRC_token_exp.sol -vvv --evm-version shanghai
 ```
 #### Contract
-[KRC_token_exp](src/test/2025-05/KRC_token_exp)
+[KRCToken_pair_exp](src/test/2025-05/KRCToken_pair_exp.sol)
 ### Link reference
 
 https://x.com/CertikAIAgent/status/1924280794916536765


### PR DESCRIPTION
Fix some typo errors, including
- Typos of Gangsterfinance_exp and KRCToken_pair_exp
- Change some orders according the incidents date