### PR TITLE
Update Phalcon Links

### DIFF
--- a/past/2022/README.md
+++ b/past/2022/README.md
@@ -3053,7 +3053,7 @@ forge test --contracts ./src/test/2022-02/TecraSpace_exp.sol -vv
 
 https://etherscan.io/address/0x6653d9bcbc28fc5a2f5fb5650af8f2b2e1695a15
 
-https://phalcon.blocksec.com/explorer/tx/eth/0x81e9918e248d14d78ff7b697355fd9f456c6d7881486ed14fdfb69db16631154
+https://app.blocksec.com/explorer/tx/eth/0x81e9918e248d14d78ff7b697355fd9f456c6d7881486ed14fdfb69db16631154
 
 ---
 

--- a/past/2023/README.md
+++ b/past/2023/README.md
@@ -1026,7 +1026,7 @@ forge test --contracts ./src/test/2023-11/KyberSwap_exp.eth.1.sol -vvv
 
 [In depth analysis](https://blocksec.com/blog/yet-another-tragedy-of-precision-loss-an-in-depth-analysis-of-the-kyber-swap-incident-1).
 
-[List of transactions](https://phalcon.blocksec.com/explorer/security-incidents?page=1).
+[List of transactions](https://app.blocksec.com/explorer/security-incidents?page=1).
 
 ---
 

--- a/past/2024/README.md
+++ b/past/2024/README.md
@@ -3096,7 +3096,7 @@ https://twitter.com/Phalcon_xyz/status/1752278614551216494
 
 https://twitter.com/peckshield/status/1752279373779194011
 
-https://phalcon.blocksec.com/explorer/security-incidents
+https://app.blocksec.com/explorer/security-incidents
 
 ---
 
@@ -3132,7 +3132,7 @@ forge test --match-contract BarleyFinance_exp -vvv
 
 #### Link reference
 
-https://phalcon.blocksec.com/explorer/security-incidents
+https://app.blocksec.com/explorer/security-incidents
 
 https://www.bitget.com/news/detail/12560603890246
 

--- a/src/test/2022-02/TecraSpace_exp.sol
+++ b/src/test/2022-02/TecraSpace_exp.sol
@@ -10,7 +10,7 @@ import "./../interface.sol";
     - Attacker: https://etherscan.io/address/0xb19b7f59c08ea447f82b587c058ecbf5fde9c299
     - Attack Contract: https://etherscan.io/address/0x6653d9bcbc28fc5a2f5fb5650af8f2b2e1695a15
     - Vuln Contract: https://etherscan.io/address/0xe38b72d6595fd3885d1d2f770aa23e94757f91a1
-    - Attack Tx: https://phalcon.blocksec.com/explorer/tx/eth/0x81e9918e248d14d78ff7b697355fd9f456c6d7881486ed14fdfb69db16631154
+    - Attack Tx: https://app.blocksec.com/explorer/tx/eth/0x81e9918e248d14d78ff7b697355fd9f456c6d7881486ed14fdfb69db16631154
 */
 interface IUSDTInterface {
     function approve(address spender, uint256 value) external;

--- a/src/test/2023-11/KyberSwap_exp.eth.1.sol
+++ b/src/test/2023-11/KyberSwap_exp.eth.1.sol
@@ -12,10 +12,10 @@ import {IPool as IKyberswapPool} from "./KyberSwap/interfaces/IPool.sol";
 // Attacker EOA: https://etherscan.io/address/0x50275E0B7261559cE1644014d4b78D4AA63BE836
 // Attacker Contracts : https://etherscan.io/address/0xaf2acf3d4ab78e4c702256d214a3189a874cdc13
 // Vulnerable Contract : https://etherscan.io/address/0xFd7B111AA83b9b6F547E617C7601EfD997F64703
-// Transaction : https://phalcon.blocksec.com/explorer/tx/eth/0x485e08dc2b6a4b3aeadcb89c3d18a37666dc7d9424961a2091d6b3696792f0f3 (block 18630392)
+// Transaction : https://app.blocksec.com/explorer/tx/eth/0x485e08dc2b6a4b3aeadcb89c3d18a37666dc7d9424961a2091d6b3696792f0f3 (block 18630392)
 
 // @Analysis
-// https://phalcon.blocksec.com/explorer/security-incidents
+// https://app.blocksec.com/explorer/security-incidents
 // https://twitter.com/BlockSecTeam/status/1727560157888942331
 // https://blocksec.com/blog/yet-another-tragedy-of-precision-loss-an-in-depth-analysis-of-the-kyber-swap-incident-1
 // https://blog.solidityscan.com/kyberswap-hack-analysis-25e25f2e4a7b

--- a/src/test/2023-12/DominoTT_exp.sol
+++ b/src/test/2023-12/DominoTT_exp.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.10;
 // Attacker : https://bscscan.com/address/0x835b45d38cbdccf99e609436ff38e31ac05bc502
 // Attack Contract : https://bscscan.com/address/0xaed80b8a821607981e5e58b7a753a3336c0bfd6f
 // Vulnerable Contract : https://bscscan.com/address/0x0dabdc92af35615443412a336344c591faed3f90
-// Attack Tx : https://phalcon.blocksec.com/explorer/tx/bsc/0x1ee617cd739b1afcc673a180e60b9a32ad3ba856226a68e8748d58fcccc877a8
+// Attack Tx : https://app.blocksec.com/explorer/tx/bsc/0x1ee617cd739b1afcc673a180e60b9a32ad3ba856226a68e8748d58fcccc877a8
 
 import "forge-std/Test.sol";
 import "./../interface.sol";

--- a/src/test/2023-12/HNet_exp.sol
+++ b/src/test/2023-12/HNet_exp.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.10;
 // Attacker : https://bscscan.com/address/0x835b45d38cbdccf99e609436ff38e31ac05bc502
 // Attack Contract : https://bscscan.com/address/0xaed80b8a821607981e5e58b7a753a3336c0bfd6f
 // Vulnerable Contract : https://bscscan.com/address/0x0dabdc92af35615443412a336344c591faed3f90
-// Attack Tx : https://phalcon.blocksec.com/explorer/tx/bsc/0x1ee617cd739b1afcc673a180e60b9a32ad3ba856226a68e8748d58fcccc877a8
+// Attack Tx : https://app.blocksec.com/explorer/tx/bsc/0x1ee617cd739b1afcc673a180e60b9a32ad3ba856226a68e8748d58fcccc877a8
 
 import "forge-std/Test.sol";
 import "./../interface.sol";

--- a/src/test/2023-12/Telcoin_exp.sol
+++ b/src/test/2023-12/Telcoin_exp.sol
@@ -7,7 +7,7 @@ import "./../interface.sol";
 // @KeyInfo - Total Lost : ~1,24M
 // Attacker : https://polygonscan.com/address/0xdb4b84f0e601e40a02b54497f26e03ef33f3a5b7
 // Vulnerable Contract : https://polygonscan.com/address/0x56bcadff30680ebb540a84d75c182a5dc61981c0
-// Attack Tx (CloneableProxy#1) : https://phalcon.blocksec.com/explorer/tx/polygon/0x35f50851c3b754b4565dc3e69af8f9bdb6555edecc84cf0badf8c1e8141d902d
+// Attack Tx (CloneableProxy#1) : https://app.blocksec.com/explorer/tx/polygon/0x35f50851c3b754b4565dc3e69af8f9bdb6555edecc84cf0badf8c1e8141d902d
 
 // @Analysis
 // https://blocksec.com/phalcon/blog/telcoin-security-incident-in-depth-analysis
@@ -19,7 +19,7 @@ interface ICloneableProxy {
 
 contract ContractTest is Test {
     // CloneableProxy#1 created and 'initialized' at tx:
-    // https://phalcon.blocksec.com/explorer/tx/polygon/0x1a31cb6f417d30fe8769328b3412bfb0d70247a82009ef28dfab5730c82acd05
+    // https://app.blocksec.com/explorer/tx/polygon/0x1a31cb6f417d30fe8769328b3412bfb0d70247a82009ef28dfab5730c82acd05
     ICloneableProxy private constant CloneableProxy = ICloneableProxy(0x56BCADff30680EBB540a84D75c182A5dC61981C0);
     IERC20 private constant TEL = IERC20(0xdF7837DE1F2Fa4631D716CF2502f8b230F1dcc32);
 

--- a/src/test/2024-01/BarleyFinance_exp.sol
+++ b/src/test/2024-01/BarleyFinance_exp.sol
@@ -8,10 +8,10 @@ import "./../interface.sol";
 // Attacker : https://etherscan.io/address/0x7b3a6eff1c9925e509c2b01a389238c1fcc462b6
 // Attack Contracts : https://etherscan.io/address/0x356e7481b957be0165d6751a49b4b7194aef18d5
 // Vuln Contract : https://etherscan.io/address/0x04c80bb477890f3021f03b068238836ee20aa0b8
-// Attack Tx : https://phalcon.blocksec.com/explorer/tx/eth/0x995e880635f4a7462a420a58527023f946710167ea4c6c093d7d193062a33b01
+// Attack Tx : https://app.blocksec.com/explorer/tx/eth/0x995e880635f4a7462a420a58527023f946710167ea4c6c093d7d193062a33b01
 
 // @Analysis
-// https://phalcon.blocksec.com/explorer/security-incidents
+// https://app.blocksec.com/explorer/security-incidents
 // https://www.bitget.com/news/detail/12560603890246
 // https://twitter.com/Phalcon_xyz/status/1751788389139992824
 
@@ -55,8 +55,8 @@ contract ContractTest is Test {
 
     function testExploit() public {
         // Start with 200 DAI tokens transferred from exploiter to attack contract in txs:
-        // https://phalcon.blocksec.com/explorer/tx/eth/0xa685928b5102349a5cc50527fec2e03cb136c233505471bdd4363d0ab077a69a
-        // https://phalcon.blocksec.com/explorer/tx/eth/0xaaa197c7478063eb1124c8d8b03016fe080e6ec4c4f4a4e6d7f09022084e3390
+        // https://app.blocksec.com/explorer/tx/eth/0xa685928b5102349a5cc50527fec2e03cb136c233505471bdd4363d0ab077a69a
+        // https://app.blocksec.com/explorer/tx/eth/0xaaa197c7478063eb1124c8d8b03016fe080e6ec4c4f4a4e6d7f09022084e3390
         // DAI tokens will be used by wBARL flash function
         deal(address(DAI), address(this), 200e18);
 

--- a/src/test/2024-01/Bmizapper_exp.sol
+++ b/src/test/2024-01/Bmizapper_exp.sol
@@ -10,7 +10,7 @@ import "./../interface.sol";
     - Attacker: https://etherscan.io/address/0x63136677355840f26c0695dd6de5c9e4f514f8e8
     - Attack Contract: https://etherscan.io/address/0xae5919160a646f5d80d89f7aae35a2ca74738440
     - Vuln Contract: https://etherscan.io/address/0x4622aff8e521a444c9301da0efd05f6b482221b8
-    - Attack Tx: https://phalcon.blocksec.com/explorer/tx/eth/0x97201900198d0054a2f7a914f5625591feb6a18e7fc6bb4f0c964b967a6c15f6
+    - Attack Tx: https://app.blocksec.com/explorer/tx/eth/0x97201900198d0054a2f7a914f5625591feb6a18e7fc6bb4f0c964b967a6c15f6
     - Analysis: https://x.com/0xmstore/status/1747756898172952725?s=20
 */
 

--- a/src/test/2024-01/CitadelFinance_exp.sol
+++ b/src/test/2024-01/CitadelFinance_exp.sol
@@ -8,7 +8,7 @@ import "./../interface.sol";
 // Attacker : https://arbiscan.io/address/0xfcf88e5e1314ca3b6be7eed851568834233f8b49
 // Attack Contract : https://arbiscan.io/address/0xfcbf411237ac830dc892edec054f15ba7f9ea5a6
 // Vuln Contract : https://arbiscan.io/address/0x34b666992fcce34669940ab6b017fe11e5750799
-// One of the attack txs : https://phalcon.blocksec.com/explorer/tx/arbitrum/0xf52a681bc76df1e3a61d9266e3a66c7388ef579d62373feb4fd0991d36006855
+// One of the attack txs : https://app.blocksec.com/explorer/tx/arbitrum/0xf52a681bc76df1e3a61d9266e3a66c7388ef579d62373feb4fd0991d36006855
 
 // @Analysis
 // https://medium.com/neptune-mutual/how-was-citadel-finance-exploited-a5f9acd0b408
@@ -65,7 +65,7 @@ contract ContractTest is Test {
 
     function testExploit() public {
         // Before attack
-        // Deposit CIT tx: https://phalcon.blocksec.com/explorer/tx/arbitrum/0xcf75802229d440e4fbabb4d357fa1886c25e9a6b5c693e9e9573c71c15e2b0d3
+        // Deposit CIT tx: https://app.blocksec.com/explorer/tx/arbitrum/0xcf75802229d440e4fbabb4d357fa1886c25e9a6b5c693e9e9573c71c15e2b0d3
         // Exploiter transfer to attack contract following amount of CIT:
         deal(address(CIT), address(this), 2653 * 1e18);
         // Approve CIT tokens to CitadelStaking contract:
@@ -142,7 +142,7 @@ contract ContractTest is Test {
 
         emit log_string("--------------------End attack--------------------");
         // After couple of above attacks, deposited CIT has been withdrawn in the following tx:
-        // https://phalcon.blocksec.com/explorer/tx/arbitrum/0x09105b771ada0c66f48786260929c0967fc822e037904ced6eac61284b6992d9
+        // https://app.blocksec.com/explorer/tx/arbitrum/0x09105b771ada0c66f48786260929c0967fc822e037904ced6eac61284b6992d9
     }
 
     function WETHToUSDC(

--- a/src/test/2024-01/MIMSpell2_exp.sol
+++ b/src/test/2024-01/MIMSpell2_exp.sol
@@ -8,13 +8,13 @@ import "./../interface.sol";
 // Attacker : https://etherscan.io/address/0x87f585809ce79ae39a5fa0c7c96d0d159eb678c9
 // Attack Contract : https://etherscan.io/address/0x193e045bee45c7573ff89b12601c745af739ce67
 // Vuln Contract : https://etherscan.io/address/0x7259e152103756e1616a77ae982353c3751a6a90
-// Attack Tx : https://phalcon.blocksec.com/explorer/tx/eth/0x26a83db7e28838dd9fee6fb7314ae58dcc6aee9a20bf224c386ff5e80f7e4cf2
+// Attack Tx : https://app.blocksec.com/explorer/tx/eth/0x26a83db7e28838dd9fee6fb7314ae58dcc6aee9a20bf224c386ff5e80f7e4cf2
 
 // @Analysis
 // https://twitter.com/kankodu/status/1752581744803680680
 // https://twitter.com/Phalcon_xyz/status/1752278614551216494
 // https://twitter.com/peckshield/status/1752279373779194011
-// https://phalcon.blocksec.com/explorer/security-incidents
+// https://app.blocksec.com/explorer/security-incidents
 
 interface IDegenBox {
     function balanceOf(address, address) external view returns (uint256);

--- a/src/test/2024-01/NBLGAME_exp.sol
+++ b/src/test/2024-01/NBLGAME_exp.sol
@@ -9,7 +9,7 @@ import "./../interface.sol";
 // Attack Contracts : https://optimistic.etherscan.io/address/0xe4d41bdd6459198b33cc795ff280cee02d91087b
 // https://optimistic.etherscan.io/address/0xfc3b08555b1c328ecf8b8a0ccd85679bf59bba4c (selfdestruct)
 // Vuln Contract : https://optimistic.etherscan.io/address/0x5499178919c79086fd580d6c5f332a4253244d91
-// Attack Tx : https://phalcon.blocksec.com/explorer/tx/optimism/0xf4fc3b638f1a377cf22b729199a9aeb27fc62fe2983a65c4d14b99ee5c5b2328
+// Attack Tx : https://app.blocksec.com/explorer/tx/optimism/0xf4fc3b638f1a377cf22b729199a9aeb27fc62fe2983a65c4d14b99ee5c5b2328
 
 // @Analysis
 // https://twitter.com/SlowMist_Team/status/1750526097106915453

--- a/src/test/2024-01/PeapodsFinance_exp.sol
+++ b/src/test/2024-01/PeapodsFinance_exp.sol
@@ -8,7 +8,7 @@ import "./../interface.sol";
 // Attacker : https://etherscan.io/address/0xbed4fbf7c3e36727ccdab4c6706c3c0e17b10397
 // Attack Contracts : https://etherscan.io/address/0xbed4fbf7c3e36727ccdab4c6706c3c0e17b10397
 // Vuln Contract : https://etherscan.io/address/0xdbb20a979a92cccce15229e41c9b082d5b5d7e31
-// Attack Tx : https://phalcon.blocksec.com/explorer/tx/eth/0x95c1604789c93f41940a7fd9eca11276975a9a65d250b89a247736287dbd2b7e
+// Attack Tx : https://app.blocksec.com/explorer/tx/eth/0x95c1604789c93f41940a7fd9eca11276975a9a65d250b89a247736287dbd2b7e
 
 interface IUniswapV3Router {
     struct ExactInputParams {

--- a/src/test/2024-01/XSIJ_exp.sol
+++ b/src/test/2024-01/XSIJ_exp.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 import "./../interface.sol";
 
 // @KeyInfo -- Total Lost : ~51K USD
-// TX : https://phalcon.blocksec.com/explorer/tx/bsc/0xf477089602fefcfc1dbdce15834476267914d64a1e6a52f07d3f135f091e1d27
+// TX : https://app.blocksec.com/explorer/tx/bsc/0xf477089602fefcfc1dbdce15834476267914d64a1e6a52f07d3f135f091e1d27
 // Attacker : https://bscscan.com/address/0xc4f82210c2952fcec77efe734ab2d9b14e858469
 // Attack Contract : https://bscscan.com/address/0x5313f4f04fdcc2330ccfa5ba7da2780850d1d7be
 // GUY : https://x.com/CertiKAlert/status/1752384801535918264

--- a/src/test/2024-02/ADC_exp.sol
+++ b/src/test/2024-02/ADC_exp.sol
@@ -4,7 +4,7 @@ import "forge-std/Test.sol";
 import "./../interface.sol";
 
 // @KeyInfo -- Total Lost : ~20 ETH
-// TX : https://phalcon.blocksec.com/explorer/tx/eth/0xcf834aff4de9992f5da9c443600dad9c6277a8a00de5007842fece51564992db
+// TX : https://app.blocksec.com/explorer/tx/eth/0xcf834aff4de9992f5da9c443600dad9c6277a8a00de5007842fece51564992db
 // Attacker : https://etherscan.io/address/0x24a0c66f185874b251eb70bee2c2e35e39848419
 // Attack Contract : https://etherscan.io/address/0x2ffdce5f0c09a8ee3a568bc01f35894b2d77a6d6
 // GUY : https://x.com/EXVULSEC/status/1753294675971313790

--- a/src/test/2024-02/AffineDeFi_exp.sol
+++ b/src/test/2024-02/AffineDeFi_exp.sol
@@ -10,7 +10,7 @@ import "./../interface.sol";
     - Attacker: https://etherscan.io/address/0x09f6be2a7d0d2789f01ddfaf04d4eaa94efc0857
     - Attack Contract: https://etherscan.io/address/0x12d85e5869258a80d4bebe70d176d0f58b2d68e4
     - Vuln Contract: https://etherscan.io/address/0xcd6ca2f0d0c182c5049d9a1f65cde51a706ae142
-    - Attack Tx: https://phalcon.blocksec.com/explorer/tx/eth/0x03543ef96c26d6c79ff6c24219c686ae6d0eb5453b322e54d3b6a5ce456385e5
+    - Attack Tx: https://app.blocksec.com/explorer/tx/eth/0x03543ef96c26d6c79ff6c24219c686ae6d0eb5453b322e54d3b6a5ce456385e5
     - Analysis: https://twitter.com/Phalcon_xyz/status/1753020812284809440
 */
 

--- a/src/test/2024-02/Babyloogn_exp.sol
+++ b/src/test/2024-02/Babyloogn_exp.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.10;
 // Attacker : https://bscscan.com/address/0x835b45d38cbdccf99e609436ff38e31ac05bc502
 // Attack Contract : https://bscscan.com/address/0x3559ee265fc9c5c9a333b07e0199480b4a84f369
 // Vulnerable Contract : https://bscscan.com/address/0x971d08bba900230298add23e61e04b04226b5073
-// Attack Tx : https://phalcon.blocksec.com/explorer/tx/bsc/0xd081d6bb96326be5305a6c00dd51d1799971794941576554341738abc1ceb202
+// Attack Tx : https://app.blocksec.com/explorer/tx/bsc/0xd081d6bb96326be5305a6c00dd51d1799971794941576554341738abc1ceb202
 
 import "forge-std/Test.sol";
 import "./../interface.sol";

--- a/src/test/2024-02/BurnsDefi_exp.sol
+++ b/src/test/2024-02/BurnsDefi_exp.sol
@@ -8,7 +8,7 @@ import "./../interface.sol";
 // Attacker : https://bscscan.com/address/0xc9fbcf3eb24385491f73bbf691b13a6f8be7c339
 // Attack Contract : https://bscscan.com/address/0xb5eebf73448e22ce6a556f848360057f6aadd4e7
 // Vuln Contract : https://bscscan.com/address/0x4fb9657ac5d311dd54b37a75cfb873b127eb21fd
-// Attack Tx : https://phalcon.blocksec.com/explorer/tx/bsc/0x1d0af3a963682748493f21bf9e955ce3a950bee5817401bf2486db7a0af104b4
+// Attack Tx : https://app.blocksec.com/explorer/tx/bsc/0x1d0af3a963682748493f21bf9e955ce3a950bee5817401bf2486db7a0af104b4
 
 // @Analysis
 // https://twitter.com/pennysplayer/status/1754342573815238946

--- a/src/test/2024-02/Game_exp.sol
+++ b/src/test/2024-02/Game_exp.sol
@@ -8,7 +8,7 @@ import "./../interface.sol";
 // Attacker : https://etherscan.io/address/0x145766a51ae96e69810fe76f6f68fd0e95675a0b
 // Attack Contract : https://etherscan.io/address/0x8d4de2bc1a566b266bd4b387f62c21e15474d12a
 // Vuln Contract : https://etherscan.io/address/0x52d69c67536f55efefe02941868e5e762538dbd6
-// Attack Tx : https://phalcon.blocksec.com/explorer/tx/eth/0x0eb8f8d148508e752d9643ccf49ac4cb0c21cbad346b5bbcf2d06974d31bd5c4
+// Attack Tx : https://app.blocksec.com/explorer/tx/eth/0x0eb8f8d148508e752d9643ccf49ac4cb0c21cbad346b5bbcf2d06974d31bd5c4
 
 // @Analysis
 // https://twitter.com/AnciliaInc/status/1757533144033739116

--- a/src/test/2024-02/PANDORA_exp.sol
+++ b/src/test/2024-02/PANDORA_exp.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.10;
 import "forge-std/Test.sol";
 import "./../interface.sol";
 
-// TX : https://phalcon.blocksec.com/explorer/tx/eth/0x7c5a909b45014e35ddb89697f6be38d08eff30e7c3d3d553033a6efc3b444fdd
+// TX : https://app.blocksec.com/explorer/tx/eth/0x7c5a909b45014e35ddb89697f6be38d08eff30e7c3d3d553033a6efc3b444fdd
 // GUY : https://twitter.com/pennysplayer/status/1766479470058406174
 // Profit : ~17K USD
 // REASON : integer underflow

--- a/src/test/2024-02/SMOOFSStaking_exp.sol
+++ b/src/test/2024-02/SMOOFSStaking_exp.sol
@@ -8,7 +8,7 @@ import "./../interface.sol";
 // Attacker : https://polygonscan.com/address/0x149b268b8b8101e2b5df84a601327484cb43221c
 // Attack Contract : https://polygonscan.com/address/0x367120bf791cc03f040e2574aea0ca7790d3d2e5
 // Vuln Contract : https://polygonscan.com/address/0x9d6cb01fb91f8c6616e822cf90a4b3d8eb0569c6
-// One of the attack txs : https://phalcon.blocksec.com/explorer/tx/polygon/0xde51af983193b1be3844934b2937a76c19610ddefcdd3ffcf127db3e68749a50
+// One of the attack txs : https://app.blocksec.com/explorer/tx/polygon/0xde51af983193b1be3844934b2937a76c19610ddefcdd3ffcf127db3e68749a50
 
 // @Analysis
 // https://twitter.com/AnciliaInc/status/1762893563103428783

--- a/src/test/2024-02/Seneca_exp.sol
+++ b/src/test/2024-02/Seneca_exp.sol
@@ -7,7 +7,7 @@ import "./../interface.sol";
 // @KeyInfo - Total Lost : ~$6M
 // Attacker : https://etherscan.io/address/0x94641c01a4937f2c8ef930580cf396142a2942dc
 // Vuln Contract : https://etherscan.io/address/0x65c210c59b43eb68112b7a4f75c8393c36491f06
-// Attack Tx : https://phalcon.blocksec.com/explorer/tx/eth/0x23fcf9d4517f7cc39815b09b0a80c023ab2c8196c826c93b4100f2e26b701286
+// Attack Tx : https://app.blocksec.com/explorer/tx/eth/0x23fcf9d4517f7cc39815b09b0a80c023ab2c8196c826c93b4100f2e26b701286
 
 // @Analysis
 // https://twitter.com/Phalcon_xyz/status/1763045563040411876

--- a/src/test/2024-03/ALP_exp.sol
+++ b/src/test/2024-03/ALP_exp.sol
@@ -6,7 +6,7 @@ import "./../interface.sol";
 
 // Attacker : https://bscscan.com/address/0xff61Ba33Ed51322BB716EAb4137Adf985644b94d
 // Attack Contract : https://bscscan.com/address/0x0edf13f6bd033f0f267d46c6e9dff9c7190e0fa0
-// Attack Tx : https://phalcon.blocksec.com/explorer/tx/bsc/0x9983ca8eaee9ee69629f74537eaf031272af75f1e5a7725911d8b06df17c67ca
+// Attack Tx : https://app.blocksec.com/explorer/tx/bsc/0x9983ca8eaee9ee69629f74537eaf031272af75f1e5a7725911d8b06df17c67ca
  
 // Profit : 10K USD
 // REASON : public interal call

--- a/src/test/2024-03/ARK_exp.sol
+++ b/src/test/2024-03/ARK_exp.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.10;
 import "forge-std/Test.sol";
 import "./../interface.sol";
 
-// TX : https://phalcon.blocksec.com/explorer/tx/bsc/0xe8b0131fa14d0a96327f6b5690159ffa7650d66376db87366ba78d91f17cd677
+// TX : https://app.blocksec.com/explorer/tx/bsc/0xe8b0131fa14d0a96327f6b5690159ffa7650d66376db87366ba78d91f17cd677
 // GUY : https://twitter.com/Phalcon_xyz/status/1771728823534375249
 // Profit : ~348BNB
 // REASON : business logic flaw

--- a/src/test/2024-03/Binemon_exp.sol
+++ b/src/test/2024-03/Binemon_exp.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.10;
 // Attacker : https://bscscan.com/address/0x835b45d38cbdccf99e609436ff38e31ac05bc502
 // Attack Contract : https://bscscan.com/address/0x132e1ea5db918dae00eef685b845c409a83dfa82
 // Vulnerable Contract : https://bscscan.com/address/0xe56842ed550ff2794f010738554db45e60730371
-// Attack Tx : https://phalcon.blocksec.com/explorer/tx/bsc/0x1999bb5c11a8d8bfa7620fc5cc37f5bc59c1a99d7a9250a8d6076c93bbdbeb5f
+// Attack Tx : https://app.blocksec.com/explorer/tx/bsc/0x1999bb5c11a8d8bfa7620fc5cc37f5bc59c1a99d7a9250a8d6076c93bbdbeb5f
 
 import "forge-std/Test.sol";
 import "./../interface.sol";

--- a/src/test/2024-03/GHT_exp.sol
+++ b/src/test/2024-03/GHT_exp.sol
@@ -8,7 +8,7 @@ import "./../interface.sol";
 // Attacker : https://etherscan.io/address/0x096f0f03e4be68d7e6dd39b22a3846b8ce9849a3
 // Attack Contract : https://etherscan.io/address/0xcc5159b5538268f45afda7b5756fa8769ce3e21f
 // Vuln Contract : https://etherscan.io/address/0x528e046acfb52bd3f9c400e7a5c79a8a2c2863d0
-// Attack Tx : https://phalcon.blocksec.com/explorer/tx/eth/0xd17266bcdf30cbcbd7d0b5a006f43141981aeee2e1f860f68c9a1805ecacbc68?line=3
+// Attack Tx : https://app.blocksec.com/explorer/tx/eth/0xd17266bcdf30cbcbd7d0b5a006f43141981aeee2e1f860f68c9a1805ecacbc68?line=3
 interface IGHT {
     function transferFrom(address, address, uint256) external;
     function balanceOf(

--- a/src/test/2024-03/IT_exp.sol
+++ b/src/test/2024-03/IT_exp.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.10;
 import "forge-std/Test.sol";
 import "./../interface.sol";
 
-// TX : https://phalcon.blocksec.com/explorer/tx/bsc/0xb33057f57ce451aa8cbb65508d298fe3c627509cc64a394736dace2671b6dcfa
+// TX : https://app.blocksec.com/explorer/tx/bsc/0xb33057f57ce451aa8cbb65508d298fe3c627509cc64a394736dace2671b6dcfa
  
 // Profit : ~13K USD
 // REASON : Business Logic Flaw

--- a/src/test/2024-03/LavaLending_exp.sol
+++ b/src/test/2024-03/LavaLending_exp.sol
@@ -9,7 +9,7 @@ import "./../interface.sol";
 // Attack Contract 1: https://arbiscan.io/address/0x3e52c217a902002ca296fe6769c22fedaee9fda1
 // Attack Contract 2: https://arbiscan.io/address/0x42fae47296b26385c4a5b62c46e4305a27c88988
 // Vulnerable Contract : https://arbiscan.io/address/0x7746872c6892bcfb4254390283719f2bd2d4da76#code
-// Attack Tx : https://phalcon.blocksec.com/explorer/tx/arbitrum/0xcb1a2f5eeb1a767ea5ccbc3665351fadc1af135d12a38c504f8f6eb997e9e603
+// Attack Tx : https://app.blocksec.com/explorer/tx/arbitrum/0xcb1a2f5eeb1a767ea5ccbc3665351fadc1af135d12a38c504f8f6eb997e9e603
 
 // @Analysis
  

--- a/src/test/2024-03/MO_exp.sol
+++ b/src/test/2024-03/MO_exp.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.10;
 import "forge-std/Test.sol";
 import "./../interface.sol";
 
-// TX : https://phalcon.blocksec.com/explorer/tx/optimism/0x4ec3061724ca9f0b8d400866dd83b92647ad8c943a1c0ae9ae6c9bd1ef789417
+// TX : https://app.blocksec.com/explorer/tx/optimism/0x4ec3061724ca9f0b8d400866dd83b92647ad8c943a1c0ae9ae6c9bd1ef789417
  
 // Profit : ~413K USD,but i get more
 // REASON : Bussiness Logic Flaw

--- a/src/test/2024-03/Paraswap_exp.sol
+++ b/src/test/2024-03/Paraswap_exp.sol
@@ -8,7 +8,7 @@ import "./../interface.sol";
 // Whitehat : https://etherscan.io/address/0xfde0d1575ed8e06fbf36256bcdfa1f359281455a
 // Whitehat Contract : https://etherscan.io/address/0x6980a47bee930a4584b09ee79ebe46484fbdbdd0
 // Vuln Contract : https://etherscan.io/address/0x00000000fdac7708d0d360bddc1bc7d097f47439
-// Attack txs : https://phalcon.blocksec.com/explorer/tx/eth/0x35a73969f582872c25c96c48d8bb31c23eab8a49c19282c67509b96186734e60
+// Attack txs : https://app.blocksec.com/explorer/tx/eth/0x35a73969f582872c25c96c48d8bb31c23eab8a49c19282c67509b96186734e60
 
 // @Analysis
 // https://medium.com/neptune-mutual/analysis-of-the-paraswap-exploit-1f97c604b4fe

--- a/src/test/2024-03/TGBS_exp.sol
+++ b/src/test/2024-03/TGBS_exp.sol
@@ -8,7 +8,7 @@ import "./../interface.sol";
 // Attacker : https://bscscan.com/address/0xff1db040e4f2a44305e28f8de728dabff58f01e1
 // Attack Contract : https://bscscan.com/address/0x1a8eb8eca01819b695637c55c1707f9497b51cd9
 // Vuln Contract : https://bscscan.com/address/0xedecfa18cae067b2489a2287784a543069f950f4
-// Attack Tx : https://phalcon.blocksec.com/explorer/tx/bsc/0xa0408770d158af99a10c60474d6433f4c20f3052e54423f4e590321341d4f2a4
+// Attack Tx : https://app.blocksec.com/explorer/tx/bsc/0xa0408770d158af99a10c60474d6433f4c20f3052e54423f4e590321341d4f2a4
 
 // @Analysis
  

--- a/src/test/2024-03/UnizenIO2_exp.sol
+++ b/src/test/2024-03/UnizenIO2_exp.sol
@@ -7,7 +7,7 @@ import "./../interface.sol";
 // @KeyInfo - Total Lost : ~$2M
 // Attacker : https://etherscan.io/address/0x2ad8aed847e8d4d3da52aabb7d0f5c25729d10df
 // Vuln Contract : https://etherscan.io/address/0xd3f64baa732061f8b3626ee44bab354f854877ac
-// One of the attack txs : https://phalcon.blocksec.com/explorer/tx/eth/0xdd0636e2598f4d7b74f364fedb38f334365fd956747a04a6dd597444af0bc1c0
+// One of the attack txs : https://app.blocksec.com/explorer/tx/eth/0xdd0636e2598f4d7b74f364fedb38f334365fd956747a04a6dd597444af0bc1c0
 
 // @Analysis
 // https://twitter.com/Phalcon_xyz/status/1766274000534004187

--- a/src/test/2024-03/UnizenIO_exp.sol
+++ b/src/test/2024-03/UnizenIO_exp.sol
@@ -6,7 +6,7 @@ import "./../interface.sol";
 // @KeyInfo - Total Lost : ~2M USD$
 // Attacker : https://etherscan.io/address/0x2ad8aed847e8d4d3da52aabb7d0f5c25729d10df
 // Vulnerable Contract : (Unizen: Trade Aggregator Proxy) https://etherscan.io/address/0xd3f64baa732061f8b3626ee44bab354f854877ac
-// Attack Tx : https://phalcon.blocksec.com/explorer/tx/eth/0x923d1d63a1165ebd3521516f6d22d015f2e1b4b22d5dc954152b6c089c765fcd ( one of the transactions)
+// Attack Tx : https://app.blocksec.com/explorer/tx/eth/0x923d1d63a1165ebd3521516f6d22d015f2e1b4b22d5dc954152b6c089c765fcd ( one of the transactions)
 
 // @Analysis
 // https://twitter.com/SlowMist_Team/status/1766311510362734824

--- a/src/test/2024-03/ZongZi_exp.sol
+++ b/src/test/2024-03/ZongZi_exp.sol
@@ -8,7 +8,7 @@ import "./../interface.sol";
 // Attacker : https://bscscan.com/address/0x2c42824ef89d6efa7847d3997266b62599560a26
 // Attack Contract : https://bscscan.com/address/0x0bd0d9ba4f52db225b265c3cffa7bc4a418d22a9
 // Vuln Contract : https://bscscan.com/address/0xb7a254237e05ccca0a756f75fb78ab2df222911b
-// Attack txs : https://phalcon.blocksec.com/explorer/tx/bsc/0x247f4b3dbde9d8ab95c9766588d80f8dae835129225775ebd05a6dd2c69cd79f
+// Attack txs : https://app.blocksec.com/explorer/tx/bsc/0x247f4b3dbde9d8ab95c9766588d80f8dae835129225775ebd05a6dd2c69cd79f
 
 // @Analysis
  

--- a/src/test/2024-04/ATM_exp.sol
+++ b/src/test/2024-04/ATM_exp.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.10;
 import "forge-std/Test.sol";
 import "./../interface.sol";
 
-// TX : https://phalcon.blocksec.com/explorer/tx/bsc/0xee10553c26742bec9a4761fd717642d19012bab1704cbced048425070ee21a8a?line=2
+// TX : https://app.blocksec.com/explorer/tx/bsc/0xee10553c26742bec9a4761fd717642d19012bab1704cbced048425070ee21a8a?line=2
  
 // Profit : ~182K USD
 // REASON : Business Logic Flaw

--- a/src/test/2024-04/BigBangSwap_exp.sol
+++ b/src/test/2024-04/BigBangSwap_exp.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.10;
 // Attacker : https://bscscan.com/address/0xc1b6f9898576d722dbf604aaa452cfea3a639c59
 // Attack Contract : https://bscscan.com/address/0xb22cf0e1672344f23f3126fbd35f856e961fd780
 // Vulnerable Contract : https://bscscan.com/address/0xa45d4359246dbd523ab690bef01da06b07450030
-// Attack Tx : https://phalcon.blocksec.com/explorer/tx/bsc/0x94055664287a565d4867a97ba6d5d2e28c55d10846e3f83355ba84bd1b9280fc
+// Attack Tx : https://app.blocksec.com/explorer/tx/bsc/0x94055664287a565d4867a97ba6d5d2e28c55d10846e3f83355ba84bd1b9280fc
 
 // @Analysis
 // https://x.com/DecurityHQ/status/1778075039293727143

--- a/src/test/2024-04/OpenLeverage2_exp.sol
+++ b/src/test/2024-04/OpenLeverage2_exp.sol
@@ -7,8 +7,8 @@ import "./../interface.sol";
 // @KeyInfo - Total Lost : ~234K
 // Attacker : https://bscscan.com/address/0x5bb5b6d41c3e5e41d9b9ed33d12f1537a1293d5f
 // Vulnerable Contract : https://bscscan.com/address/0xf436f8fe7b26d87eb74e5446acec2e8ad4075e47
-// Attack Tx 1 : https://phalcon.blocksec.com/explorer/tx/bsc/0xf78a85eb32a193e3ed2e708803b57ea8ea22a7f25792851e3de2d7945e6d02d5
-// Attack Tx 2 : https://phalcon.blocksec.com/explorer/tx/bsc/0x210071108f3e5cd24f49ef4b8bcdc11804984b0c0334e18a9a2cdb4cd5186067
+// Attack Tx 1 : https://app.blocksec.com/explorer/tx/bsc/0xf78a85eb32a193e3ed2e708803b57ea8ea22a7f25792851e3de2d7945e6d02d5
+// Attack Tx 2 : https://app.blocksec.com/explorer/tx/bsc/0x210071108f3e5cd24f49ef4b8bcdc11804984b0c0334e18a9a2cdb4cd5186067
 
 // @Analysis
  


### PR DESCRIPTION
Due to changes in Phalcon, the old links no longer point to the correct transactions.
This PR updates the URLs accordingly to ensure transaction links remain valid.