### PR TITLE
Fix typos and spelling errors across documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 [20260109 TRU](#20260109-truebit---overflow)
 
-[20260101 PRXVT](#20260101-PRXVT---bussiness-logic-flaw)
+[20260101 PRXVT](#20260101-PRXVT---business-logic-flaw)
 
 <details> <summary> 2025 </summary>
 
@@ -84,7 +84,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 [20250918 NGP](past/2025/README.md#20250918-ngp---price-manipulation)
 
-[20250913 Kame](past/2025/README.md#20250913-kame---arbitary-external-call)
+[20250913 Kame](past/2025/README.md#20250913-kame---arbitrary-external-call)
 
 [20250830 EverValueCoin](past/2025/README.md#20250830-evervaluecoin---arbitrage)
 
@@ -548,7 +548,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 [20240312 BBT](past/2024/README.md#20240312-bbt---business-logic-flaw)
 
-[20240311 Binemon](past/2024/README.md#20240311-Binemon---precission-loss)
+[20240311 Binemon](past/2024/README.md#20240311-Binemon---precision-loss)
 
 [20240309 Juice](past/2024/README.md#20240309-juice---business-logic-flaw)
 
@@ -606,7 +606,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 [20240130 XSIJ](past/2024/README.md#20240130-xsij---business-logic-flaw)
 
-[20240130 MIMSpell](past/2024/README.md#20240130-mimspell---precission-loss)
+[20240130 MIMSpell](past/2024/README.md#20240130-mimspell---precision-loss)
 
 [20240129 PeapodsFinance](past/2024/README.md#20240128-PeapodsFinance---reentrancy)
 
@@ -736,7 +736,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 [20231106 TheStandard_io](past/2023/README.md#20231106-thestandard_io---lack-of-slippage-protection)
 
-[20231106 KR](past/2023/README.md#20231106-KR---precission-loss)
+[20231106 KR](past/2023/README.md#20231106-KR---precision-loss)
 
 [20231102 BRAND](past/2023/README.md#20231102-brand---lack-of-access-control)
 
@@ -744,7 +744,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 [20231101 SwampFinance](past/2023/README.md#20231101-swampfinance---business-logic-flaw)
 
-[20231101 OnyxProtocol](past/2023/README.md#20231101-onyxprotocol---precission-loss-vulnerability)
+[20231101 OnyxProtocol](past/2023/README.md#20231101-onyxprotocol---precision-loss-vulnerability)
 
 [20231031 UniBotRouter](past/2023/README.md#20231031-UniBotRouter---arbitrary-external-call)
 
@@ -862,7 +862,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 [20230715 USDTStakingContract28](past/2023/README.md#20230715-usdtstakingcontract28---lack-of-access-control)
 
-[20230712 Platypus](past/2023/README.md#20230712-platypus---bussiness-logic-flaw)
+[20230712 Platypus](past/2023/README.md#20230712-platypus---business-logic-flaw)
 
 [20230712 WGPT](past/2023/README.md#20230712-wgpt---business-logic-flaw)
 
@@ -886,15 +886,15 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 [20230630 Biswap](past/2023/README.md#20230630-biswap---v3migrator-exploit)
 
-[20230630 MyAi](past/2023/README.md#20230630-MyAi---business-loigc)
+[20230630 MyAi](past/2023/README.md#20230630-MyAi---business-logic)
 
 [20230628 Themis](past/2023/README.md#20230628-themis---manipulation-of-prices-using-flashloan)
 
-[20230627 UnverifiedContr_9ad32](past/2023/README.md#20230627-unverifiedcontr_9ad32---business-loigc-flaw)
+[20230627 UnverifiedContr_9ad32](past/2023/README.md#20230627-unverifiedcontr_9ad32---business-logic-flaw)
 
-[20230627 STRAC](past/2023/README.md#20230627-STRAC---business-loigc)
+[20230627 STRAC](past/2023/README.md#20230627-STRAC---business-logic)
 
-[20230623 SHIDO](past/2023/README.md#20230623-shido---business-loigc)
+[20230623 SHIDO](past/2023/README.md#20230623-shido---business-logic)
 
 [20230621 BabyDogeCoin02](past/2023/README.md#20230621-babydogecoin02---lack-slippage-protection)
 
@@ -902,7 +902,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 [20230620 MIM](past/2023/README.md#20230620-mimspell---arbitrary-external-call-vulnerability)
 
-[20230619 Contract_0x7657](past/2023/README.md#20230620-Contract_0x7657---business-loigc)
+[20230619 Contract_0x7657](past/2023/README.md#20230619-Contract_0x7657---business-logic)
 
 [20230618 ARA](past/2023/README.md#20230618-ara---incorrect-handling-of-permissions)
 

--- a/academy/onchain_debug/04_write_your_own_poc/en/readme.md
+++ b/academy/onchain_debug/04_write_your_own_poc/en/readme.md
@@ -12,10 +12,10 @@ This article is published on XREX and [WTF Academy](https://github.com/AmazingAn
     - On 20220913 A MEV Bot was exploited by an attacker and all the assets on the contract were transferred away, with a total loss of about $140K.
     - The attacker sends a private transaction through the BNB48 validator node, similar to Flashbot not putting the transaction into the public mempool to avoid being Front-running.
 - Analysis
-    - Attacker's [TXID](https://bscscan.com/tx/0xd48758ef48d113b78a09f7b8c7cd663ad79e9965852e872fdfc92234c3e598d2)，We can see that the MEV Bot contract was unverify which was not open source，How did the attacker exploit it?
+    - Attacker's [TXID](https://bscscan.com/tx/0xd48758ef48d113b78a09f7b8c7cd663ad79e9965852e872fdfc92234c3e598d2), we can see that the MEV Bot contract was unverified which was not open source. How did the attacker exploit it?
     - Using [phalcon](https://phalcon.blocksec.com/tx/bsc/0xd48758ef48d113b78a09f7b8c7cd663ad79e9965852e872fdfc92234c3e598d2) to check，from the part of funs flow within this transaction, MEV bot transferred 6 kinds of assets to the attacker’s wallet, How did the attacker exploit it?
 ![圖片](https://user-images.githubusercontent.com/52526645/211201079-e7c5cc3b-64f8-4146-ab0e-7dd46b535cc9.png)
-    - Let’s look at the invocation process of Function call, and see that the `pancakeCall` function wss called exactly 6 times.
+    - Let's look at the invocation process of Function call, and see that the `pancakeCall` function was called exactly 6 times.
         - From: `0xee286554f8b315f0560a15b6f085ddad616d0601`
         - Attacker's contract: `0x5cb11ce550a2e6c24ebfc8df86c5757b596e69c1`
         - MEV Bot contract: `0x64dd59d6c7f09dc05b472ce5cb961b6e10106e1d`

--- a/past/2023/README.md
+++ b/past/2023/README.md
@@ -98,7 +98,7 @@
 
 [20231106 TheStandard_io](#20231106-thestandard_io---lack-of-slippage-protection)
 
-[20231106 KR](#20231106-KR---precission-loss)
+[20231106 KR](#20231106-KR---precision-loss)
 
 [20231102 BRAND](#20231102-brand---lack-of-access-control)
 
@@ -106,7 +106,7 @@
 
 [20231101 SwampFinance](#20231101-swampfinance---business-logic-flaw)
 
-[20231101 OnyxProtocol](#20231101-onyxprotocol---precission-loss-vulnerability)
+[20231101 OnyxProtocol](#20231101-onyxprotocol---precision-loss-vulnerability)
 
 [20231031 UniBotRouter](#20231031-UniBotRouter---arbitrary-external-call)
 
@@ -224,7 +224,7 @@
 
 [20230715 USDTStakingContract28](#20230715-usdtstakingcontract28---lack-of-access-control)
 
-[20230712 Platypus](#20230712-platypus---bussiness-logic-flaw)
+[20230712 Platypus](#20230712-platypus---business-logic-flaw)
 
 [20230712 WGPT](#20230712-wgpt---business-logic-flaw)
 

--- a/past/2024/README.md
+++ b/past/2024/README.md
@@ -1943,7 +1943,7 @@ https://twitter.com/Phalcon_xyz/status/1785508900093194591
 
 ---
 
-### 20240427 BNBX - precission loss
+### 20240427 BNBX - precision loss
 
 ### Lost: ~75 $BNB
 
@@ -2219,7 +2219,7 @@ https://x.com/hipalex921/status/1778482890705416323?t=KvvG83s7SXr9I55aftOc6w&s=0
 
 ---
 
-### 20240410 BigBangSwap - precission loss
+### 20240410 BigBangSwap - precision loss
 
 ### Lost: $~5K $BUSD
 
@@ -2547,7 +2547,7 @@ https://x.com/8olidity/status/1767470002566058088
 
 ---
 
-### 20240311 Binemon - precission-loss
+### 20240311 Binemon - precision-loss
 
 ### Lost: ~0.2 BNB
 

--- a/past/2025/README.md
+++ b/past/2025/README.md
@@ -152,7 +152,7 @@ https://blog.solidityscan.com/ngp-token-hack-analysis-414b6ca16d96
 
 ---
 
-### 20250913 Kame - Arbitary External Call
+### 20250913 Kame - Arbitrary External Call
 
 ### Lost: 18167.8 USD
 


### PR DESCRIPTION
## Summary
- Fix "bussiness" -> "business" in README.md and past/2023/README.md
- Fix "precission" -> "precision" in README.md, past/2023/README.md and past/2024/README.md
- Fix "loigc" -> "logic" in README.md links
- Fix "arbitary" -> "arbitrary" in README.md and past/2025/README.md
- Fix "unverify" -> "unverified" and "wss" -> "was" in academy documentation
- Correct date mismatch in Contract_0x7657 link (20230620 -> 20230619)

## Test plan
- [x] Verified all changes are documentation only (no code changes)
- [x] Verified anchor links are consistent with headers