### PR TITLE
Fix typos in academy documentation

### DIFF
--- a/academy/onchain_debug/06_write_your_own_poc/en/readme.md
+++ b/academy/onchain_debug/06_write_your_own_poc/en/readme.md
@@ -140,7 +140,7 @@ Reentrancy Attacks can be mainly identified into three types:
   
   ![image](https://user-images.githubusercontent.com/53768199/215330576-d15642f7-5819-4e83-a8c8-1d3a48ad8c6d.png)
   
-  At this point, it is known that the completion of the flash loan is determined by checking whether the corresponding token assets in the contract are greater than or equal to the state before the execution of the flash loan callback. And `depoit` function will make this validation complete.
+  At this point, it is known that the completion of the flash loan is determined by checking whether the corresponding token assets in the contract are greater than or equal to the state before the execution of the flash loan callback. And `deposit` function will make this validation complete.
 
   ```solidity
   require(balance0Before.add(fee0) <= balance0After, 'Curve/insufficient-token0-returned');

--- a/academy/solidity/01_audit/readme.md
+++ b/academy/solidity/01_audit/readme.md
@@ -1,6 +1,6 @@
 # 第一課：智能合約審計方法與技巧
 
-Author：[Sm4rty](https://twitter.com/Sm4rty_)
+Author: [Sm4rty](https://twitter.com/Sm4rty_)
 
 Translation: [SunSec](https://twitter.com/1nf0s3cpt)
 

--- a/academy/solidity/02_first_deposit/en/readme.md
+++ b/academy/solidity/02_first_deposit/en/readme.md
@@ -1,6 +1,6 @@
 # Lesson 2: First Deposit Bug in CompoundV2 and its forks
 
-Author：[Akshay Srivastav](https://twitter.com/akshaysrivastv)
+Author: [Akshay Srivastav](https://twitter.com/akshaysrivastv)
 
 **Note: Compound has been addressed this issue, this article is written for educational purposes only.**
 

--- a/academy/solidity/03_lsd_audit/en/readme.md
+++ b/academy/solidity/03_lsd_audit/en/readme.md
@@ -1,6 +1,6 @@
 # Lesson 3: Guidelines for Auditing Staking Protocols
 
-Author:[QuillAudits](https://twitter.com/QuillAudits)
+Author: [QuillAudits](https://twitter.com/QuillAudits)
 
 This document outlines the concept of liquidity staking protocols and auditing guidelines for staking protocols. The guidelines cover a range of vulnerable spots such as withdrawal mechanisms, rounding errors, external calls, fee logic, loops, structs, staking duration, and so on. 
 


### PR DESCRIPTION
## Summary
- Fix "depoit" -> "deposit" in academy/onchain_debug/06_write_your_own_poc/en/readme.md
- Fix missing space after "Author:" colon in academy/solidity documentation files

## Test plan
- [x] Verified all changes are documentation only (no code changes)