### PR TITLE
refactor: enhance git command execution robustness in add_new_entry.py

### DIFF
--- a/add_new_entry.py
+++ b/add_new_entry.py
@@ -684,10 +684,16 @@ class GitManager:
             print("Git command is not available. Skipping uncommitted file retrieval.")
             return []
         
-        command = f"git ls-files --others --exclude-standard {self.constants.SRC_TEST_DIR}/**/*.sol"
-        output = subprocess.check_output(command, shell=True, text=True)
-        uncommitted_files = output.strip().split("\n")
-        return uncommitted_files
+        try:
+            # Use argument list instead of shell=True for better robustness
+            args = ["git", "ls-files", "--others", "--exclude-standard", self.constants.SRC_TEST_DIR]
+            output = subprocess.check_output(args, text=True)
+            files = output.strip().split("\n")
+            # Filter for .sol files manually to avoid shell globbing issues
+            uncommitted_files = [f for f in files if f.endswith(".sol") and f]
+            return uncommitted_files
+        except subprocess.CalledProcessError:
+            return []
     
     def get_recently_committed_sol_files(self) -> list:
         """Get list of recently committed .sol files"""
@@ -695,10 +701,16 @@ class GitManager:
             print("Git command is not available. Skipping recently committed file retrieval.")
             return []
         
-        command = f"git diff --name-only HEAD~1 HEAD {self.constants.SRC_TEST_DIR}/**/*.sol"
-        output = subprocess.check_output(command, shell=True, text=True)
-        recently_committed_files = output.strip().split("\n")
-        return recently_committed_files
+        try:
+            # Use argument list and specify the directory to restrict the diff
+            args = ["git", "diff", "--name-only", "HEAD~1", "HEAD", "--", self.constants.SRC_TEST_DIR]
+            output = subprocess.check_output(args, text=True)
+            files = output.strip().split("\n")
+            # Filter for .sol files
+            recently_committed_files = [f for f in files if f.endswith(".sol") and f]
+            return recently_committed_files
+        except subprocess.CalledProcessError:
+            return []
 
 
 ######################


### PR DESCRIPTION
Updating the `GitManager` class to avoid relying on shell expansion and `shell=True` when retrieving Solidity files. Using `shell=True` with string interpolation is generally a brittle practice, especially when dealing with path specifications. By switching to argument lists (array-based) and implementing manual `.sol` filtering in Python, we make the internal utility script significantly more stable and predictable across different environments.

Running `git ls-files` and `git diff` directly with the target directory ensures that the file discovery logic remains precise. I've also added basic error handling for subprocess calls to prevent the script from crashing if a git command fails. These changes keep the maintainer workflow robust while maintaining the original functionality of the script.