### PR TITLE
feat: add multi-asset balance logging to BaseTestWithBalanceLog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Thank you for your interest in contributing to the DeFiHackLabs project! We appr
 ## Table of Contents
 * [Prerequisites](#prerequisites)
 * [Adding a New Incident Entry](#adding-a-new-incident-entry)
+* [Balance Logging in POCs](#balance-logging-in-pocs)
 * [Important Notes](#important-notes)
 
 ## Prerequisites
@@ -126,6 +127,69 @@ The script automatically handles:
 3. Open a pull request from your forked repository to the main DeFiHackLabs repository. Provide a clear description of the incident you added.
 
 4. Our maintainers will review your pull request. They may provide feedback or request further changes. Once your pull request is approved, it will be merged into the main repository.
+
+## Balance Logging in POCs
+
+All POCs should inherit from `BaseTestWithBalanceLog` (in `src/test/basetest.sol`) instead of `forge-std/Test.sol` directly. It provides automatic before/after balance logging via the `balanceLog` modifier.
+
+### Single-asset mode (default)
+
+Set `fundingToken` to the token the attacker profits in. Use `address(0)` for native coin (ETH, BNB, etc.). The `balanceLog` modifier will log that token's balance before and after `testExploit()`.
+
+```solidity
+contract MyExploit is BaseTestWithBalanceLog {
+    function setUp() public {
+        vm.createSelectFork("mainnet", BLOCK);
+        fundingToken = address(WETH); // log WETH profit
+    }
+
+    function testExploit() public balanceLog {
+        // exploit logic
+    }
+}
+```
+
+### Multi-asset mode
+
+When an exploit touches multiple tokens (e.g. lending pool drains across several reserves), enable multi-asset logging:
+
+1. Set `multiAssetLog = true`
+2. Populate `fundingTokens[]` with every token you want tracked
+3. Use the same `balanceLog` modifier — no override needed
+
+```solidity
+contract MyExploit is BaseTestWithBalanceLog {
+    function setUp() public {
+        vm.createSelectFork("mainnet", BLOCK);
+        multiAssetLog = true;
+        fundingTokens = new address[](3);
+        fundingTokens[0] = address(USDC);
+        fundingTokens[1] = address(WETH);
+        fundingTokens[2] = address(0); // native ETH
+    }
+
+    function testExploit() public balanceLog {
+        // exploit logic — all three tokens logged before and after
+    }
+}
+```
+
+Or add tokens one at a time using the helper:
+
+```solidity
+_addFundingToken(address(USDC));
+_addFundingToken(address(WETH));
+```
+
+### Setting a custom attacker address
+
+By default balances are logged for `address(this)` (the test contract). If the exploit profits to a separate address, set the `attacker` field:
+
+```solidity
+attacker = 0xDeaDBeef...; // log this address instead of address(this)
+```
+
+Leave it unset (or set to `address(0)`) to keep the default `address(this)` behaviour.
 
 ## Important Notes
  - **The script automatically generates blockchain explorer URLs** - do not paste explorer URLs manually

--- a/src/test/2022-03/Agave_exp.sol
+++ b/src/test/2022-03/Agave_exp.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.10;
 
-import "forge-std/Test.sol";
+import "./../basetest.sol";
 import "./../interface.sol";
 
 interface IGnosisBridgedAsset is IERC20 {
@@ -40,7 +40,7 @@ Detailed explanation of the agave exploit attack flow:
 Note: These concise steps outline the specific actions taken in each phase of the agave exploit, providing a clear understanding of the attack flow.
 */
 
-contract AgaveExploit is Test {
+contract AgaveExploit is BaseTestWithBalanceLog {
     //Prepare numbers
     uint256 linkLendNum1 = 1.0000000000000002 ether;
     uint256 wethlendnum2 = 1;
@@ -60,10 +60,7 @@ contract AgaveExploit is Test {
     address usdc = 0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83;
     address wxdai = 0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d;
 
-    // Array of assets with weth at the end
-    address[] assetAddrs;
-    string[] assetNames = ["USDC", "GNO", "LINK", "WBTC", "WXDAI", "WETH", "aWETH"];
-    uint8[] assetDecimals = [6, 18, 18, 8, 18, 18, 18];
+    // Array of assets with weth at the end (uses fundingTokens from BaseTestWithBalanceLog)
 
     address provider = 0xA91B9095eFa6C0568467562032202108e49c9Ef8;
     //Address that can mint tokens on gnosis bridge
@@ -78,12 +75,6 @@ contract AgaveExploit is Test {
 
     uint256 ethFlashloanAmt = 2728.934387414251504146 ether + 1;
 
-    modifier balanceLog() {
-        _logBalances("Before hack balances");
-        _;
-        _logBalances("After hack balances");
-    }
-
     modifier boostLTVHack() {
         lendingPool.deposit(weth, WETH.balanceOf(address(this)) - 1, address(this), 0);
         _;
@@ -97,38 +88,20 @@ contract AgaveExploit is Test {
         return IERC20(asset).balanceOf(address(this));
     }
 
-    function _logBalances(
-        string memory message
-    ) internal {
-        console.log(message);
-        console.log("--- Start of balances ---");
-        
-        for (uint i = 0; i < assetAddrs.length; i++) {
-            emit log_named_decimal_uint(
-                string.concat(assetNames[i], " Balance"), 
-                _getTokenBal(assetAddrs[i]), 
-                assetDecimals[i]
-            );
-        }
-        
-        emit log_named_decimal_uint("healthf", _getHealthFactor(), 18);
-        console.log("--- End of balances ---");
-    }
-
     function setUp() public {
         vm.createSelectFork("gnosis", 21_120_283); //fork gnosis at block number 21120319
         lendingPool = ILendingPool(ILendingPoolAddressesProvider(provider).getLendingPool());
         wethLiqBeforeHack = _getAvailableLiquidity(weth);
 
-        // Initialize asset array
-        assetAddrs = new address[](7);
-        assetAddrs[0] = usdc;
-        assetAddrs[1] = gno;
-        assetAddrs[2] = link;
-        assetAddrs[3] = wbtc;
-        assetAddrs[4] = wxdai;
-        assetAddrs[5] = weth;
-        assetAddrs[6] = aweth;
+        multiAssetLog = true;
+        fundingTokens = new address[](7);
+        fundingTokens[0] = usdc;
+        fundingTokens[1] = gno;
+        fundingTokens[2] = link;
+        fundingTokens[3] = wbtc;
+        fundingTokens[4] = wxdai;
+        fundingTokens[5] = weth;
+        fundingTokens[6] = aweth;
 
         //Lets just mint weth to this contract for initial debt
         vm.startPrank(tokenOwner);
@@ -219,7 +192,7 @@ contract AgaveExploit is Test {
     function borrowTokens() internal boostLTVHack {
         // Borrow all assets except weth (which is at index 5)
         for (uint i = 0; i < 5; i++) {
-            _borrow(assetAddrs[i]);
+            _borrow(fundingTokens[i]);
         }
     }
 

--- a/src/test/2025-12/yETH_exp.sol
+++ b/src/test/2025-12/yETH_exp.sol
@@ -53,28 +53,18 @@ contract YETHExploitTest is BaseTestWithBalanceLog {
     IERC20 constant YETH = IERC20(0x1BED97CBC3c24A4fb5C069C6E311a967386131f7);
     IOETH constant OETH = IOETH(0x39254033945AA2E4809Cc2977E7087BEE48bd7Ab);
 
-    address[] internal assetsToLog;
-    modifier balanceLog() override {
-        //Set eth bal to 0
-        vm.deal(address(this), 0);
-        logMultipleTokenBalances(assetsToLog, address(this), "Before exploit");
-        _;
-        logMultipleTokenBalances(assetsToLog, address(this), "After exploit");
-    }
-
     function setUp() public {
         vm.createSelectFork("mainnet", FORK_BLOCK);
         fundingToken = address(0);
-        assetsToLog = new address[](NUM_ASSETS + 2);
+        multiAssetLog = true;
+        fundingTokens = new address[](NUM_ASSETS + 2);
 
-        // Get all pool assets
         for (uint256 i = 0; i < NUM_ASSETS; i++) {
-            assetsToLog[i] = POOL.assets(i);
+            fundingTokens[i] = POOL.assets(i);
         }
 
-        // Add YETH and ETH
-        assetsToLog[NUM_ASSETS] = address(YETH);
-        assetsToLog[NUM_ASSETS + 1] = address(0); // ETH
+        fundingTokens[NUM_ASSETS] = address(YETH);
+        fundingTokens[NUM_ASSETS + 1] = address(0); // ETH
     }
 
     function testExploit() public balanceLog {

--- a/src/test/basetest.sol
+++ b/src/test/basetest.sol
@@ -4,8 +4,27 @@ pragma solidity ^0.8.15;
 import "./tokenhelper.sol";
 import "forge-std/Test.sol";
 
+// Base contract for DeFi exploit POCs. Inherit from this instead of Test directly.
+// Provides before/after balance logging via the `balanceLog` modifier.
+//
+// Single-asset mode (default):
+//   Set `fundingToken` to the token you profit in (address(0) = native ETH/chain coin).
+//   The `balanceLog` modifier logs that one token before and after testExploit().
+//
+// Multi-asset mode:
+//   Set `multiAssetLog = true` and populate `fundingTokens` with every token you want tracked.
+//   The same `balanceLog` modifier will log all of them. No override needed.
+//   Optionally set `attacker` to log a different address (e.g. a separate profit contract).
+//   If `attacker` is left as address(0), it resolves to address(this).
 contract BaseTestWithBalanceLog is Test {
+    // Single-asset mode: the token to log profit in. address(0) = native coin.
     address fundingToken = address(0);
+    // Multi-asset mode: full list of tokens to track (ERC-20 or address(0) for native).
+    address[] fundingTokens;
+    // Set to true to enable multi-asset logging via fundingTokens[].
+    bool multiAssetLog = false;
+    // Address whose balances are logged. Defaults to address(this) when left as address(0).
+    address attacker;
 
     struct ChainInfo {
         string name;
@@ -61,11 +80,24 @@ contract BaseTestWithBalanceLog is Test {
         emit log_named_decimal_uint(string(abi.encodePacked(label, " ", symbol, " Balance")), balance, decimals);
     }
 
+    function _attacker() private view returns (address) {
+        return attacker == address(0) ? address(this) : attacker;
+    }
+
     modifier balanceLog() virtual {
-        if (fundingToken == address(0)) vm.deal(address(this), 0);
-        _logTokenBalance(fundingToken, address(this), string(abi.encodePacked("Attacker Before exploit")));
+        if (multiAssetLog) {
+            if (fundingToken == address(0)) vm.deal(_attacker(), 0);
+            _logMultiAssetBalances("Before exploit");
+        } else {
+            if (fundingToken == address(0)) vm.deal(_attacker(), 0);
+            _logTokenBalance(fundingToken, _attacker(), "Attacker Before exploit");
+        }
         _;
-        _logTokenBalance(fundingToken, address(this), string(abi.encodePacked("Attacker After exploit")));
+        if (multiAssetLog) {
+            _logMultiAssetBalances("After exploit");
+        } else {
+            _logTokenBalance(fundingToken, _attacker(), "Attacker After exploit");
+        }
     }
 
     modifier balanceLog2(address target) virtual {
@@ -92,5 +124,19 @@ contract BaseTestWithBalanceLog is Test {
         for (uint256 i = 0; i < tokens.length; i++) {
             _logTokenBalance(tokens[i], account, "");
         }
+    }
+
+    function _addFundingToken(address token) internal {
+        fundingTokens.push(token);
+    }
+
+    function _addFundingTokens(address[] memory tokens) internal {
+        for (uint256 i = 0; i < tokens.length; i++) {
+            fundingTokens.push(tokens[i]);
+        }
+    }
+
+    function _logMultiAssetBalances(string memory label) internal {
+        logMultipleTokenBalances(fundingTokens, _attacker(), label);
     }
 }


### PR DESCRIPTION
## Summary

- **New fields in `BaseTestWithBalanceLog`**: `fundingTokens[]`, `multiAssetLog` (default `false`), and `attacker` address (defaults to `address(this)`)
- **`balanceLog` modifier updated**: when `multiAssetLog = true`, logs all tokens in `fundingTokens[]` before and after the exploit — no modifier override needed in the POC
- **Helpers added**: `_addFundingToken()`, `_addFundingTokens()`, `_logMultiAssetBalances()`
- **Agave_exp refactored**: now extends `BaseTestWithBalanceLog`, removes local asset name/decimal arrays and `_logBalances`, uses `fundingTokens[]` from base
- **yETH_exp refactored**: removes local `assetsToLog` override, uses `multiAssetLog` + `fundingTokens[]` from base
- **CONTRIBUTING.md updated**: new "Balance Logging in POCs" section with examples for single-asset, multi-asset, and custom attacker address usage

## Usage

```solidity
contract MyExploit is BaseTestWithBalanceLog {
    function setUp() public {
        multiAssetLog = true;
        fundingTokens = new address[](3);
        fundingTokens[0] = address(USDC);
        fundingTokens[1] = address(WETH);
        fundingTokens[2] = address(0); // native ETH
        // attacker defaults to address(this)
    }

    function testExploit() public balanceLog { ... }
}
```

## Test plan

- [ ] `forge build` passes with no new errors
- [ ] `forge test --contracts src/test/2022-03/Agave_exp.sol -vvv` shows multi-asset before/after log
- [ ] `forge test --contracts src/test/2025-12/yETH_exp.sol -vvv` shows multi-asset before/after log
- [ ] Existing single-asset POCs using `balanceLog` are unaffected (default `multiAssetLog = false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)