### PR TITLE
Fix: add_new_entry converts block timestamps in local time instead of UTC

### DIFF
--- a/add_new_entry.py
+++ b/add_new_entry.py
@@ -3,7 +3,7 @@
 DeFi Hack Manager - A tool for documenting and managing DeFi hack POCs
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 import argparse
 import re
 import os
@@ -14,6 +14,15 @@ from typing import Optional, Dict, List, Any, Tuple
 import sys
 import unittest
 from unittest import mock
+
+def utc_now() -> datetime:
+    """Current UTC wall clock as a naive datetime.
+
+    Hack dates are recorded in UTC, so the fallback "current time" must not
+    depend on the timezone of the machine running this script.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
 
 ######################
 # CONSTANTS
@@ -443,13 +452,13 @@ class TransactionManager:
     def get_timestamp_from_str(self, timestampstr: str) -> datetime:
         """Convert timestamp string to datetime object"""
         if not timestampstr:
-            return datetime.now()
+            return utc_now()
         try:
             return datetime.strptime(timestampstr, "%b-%d-%Y %I:%M:%S %p")
         except ValueError:
             print("Invalid timestamp format. Please use 'Mon-DD-YYYY HH:MM:SS AM/PM' (e.g., Mar-21-2024 02:51:33 PM).")
             print("Using current timestamp instead.")
-            return datetime.now()
+            return utc_now()
     
     def get_timestamp_from_tx_hash(self, tx_hash: str, rpc_url: str, auto_confirm: bool = False) -> str:
         """Get timestamp from transaction hash.
@@ -485,7 +494,9 @@ class TransactionManager:
                                 else:
                                     unix_timestamp = int(unix_timestamp_any)
                                 
-                                dt_object = datetime.fromtimestamp(unix_timestamp)
+                                # Block timestamps are UTC; render them as UTC so the
+                                # generated date does not depend on the runner's timezone.
+                                dt_object = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
                                 suggested_timestamp_str = dt_object.strftime("%b-%d-%Y %I:%M:%S %p")
                                 print(f"Suggested timestamp: {suggested_timestamp_str}")
                                 if auto_confirm or input("Use suggested timestamp? (yes/no): ").lower() == 'yes':
@@ -655,7 +666,7 @@ class PocManager:
                                 hacking_god_url: str, selected_network: str, timestamp_str: str):
         """Create a new Solidity POC file from template"""
         # Parse timestamp and format date for path
-        timestamp = datetime.strptime(timestamp_str, "%b-%d-%Y %I:%M:%S %p") if timestamp_str else datetime.now()
+        timestamp = datetime.strptime(timestamp_str, "%b-%d-%Y %I:%M:%S %p") if timestamp_str else utc_now()
         formatted_date_for_path = timestamp.strftime("%Y-%m")
         
         # Ensure file name has proper extension

--- a/test.py
+++ b/test.py
@@ -378,7 +378,7 @@ class TestTransactionManager(unittest.TestCase):
         
         # Mock successful transaction data fetch
         tx_data = {"blockNumber": 12345}
-        block_data = {"timestamp": 1647888693}  # Tue Mar 22 2022 02:51:33 GMT+0000
+        block_data = {"timestamp": 1647888693}  # Mon Mar 21 2022 18:51:33 GMT+0000
         
         with mock.patch.object(self.tx_manager, "_run_cast_command") as mock_run_cast:
             mock_run_cast.side_effect = [tx_data, block_data]
@@ -386,9 +386,9 @@ class TestTransactionManager(unittest.TestCase):
             
             result = self.tx_manager.get_timestamp_from_tx_hash(tx_hash, rpc_url)
             
-            # Assert the function returns formatted timestamp
-            # The exact format will depend on the locale, so we check for key parts
-            self.assertIn("Mar-22-2022", result)
+            # Block timestamps are UTC, so the result must not depend on the
+            # timezone of the machine running the tests.
+            self.assertEqual(result, "Mar-21-2022 06:51:33 PM")
             mock_run_cast.assert_any_call(
                 ["tx", tx_hash, "--json"],
                 rpc_url,


### PR DESCRIPTION
## Problem

`TransactionManager.get_timestamp_from_tx_hash` converts the block timestamp with:

```python
dt_object = datetime.fromtimestamp(unix_timestamp)
```

`datetime.fromtimestamp()` without a `tz` argument renders in **the timezone of the machine running the script**. Block timestamps are UTC seconds since epoch, so the result depends on who ran `add_new_entry.py`.

That timestamp is not cosmetic — it drives two things:

| consumer | code |
|---|---|
| README entry date | `timestamp.strftime("%Y%m%d")` → `20250918 NGP` |
| PoC directory | `timestamp.strftime("%Y-%m")` → `src/test/2025-09/` |

So the same attack tx yields a different README date, and possibly a different month directory, for a contributor in Taipei vs. Berlin vs. New York.

## The repo records UTC

Checked existing entries against chain data. The discriminating case is one where UTC and UTC+8 fall on different days:

| entry | attack tx block time (UTC) | UTC date | UTC+8 date | README says |
|---|---|---|---|---|
| IdolsNFT | 2025-01-14 **17:31** | 20250114 | 20250115 | **20250114** ✅ UTC |
| NGP | 2025-09-17 **19:02** | 20250917 | 20250918 | **20250918** ❌ |

`20250918 NGP` is a day late — exactly the symptom of a UTC+8 machine having generated it.

## The existing test already catches this

`test_get_timestamp_from_tx_hash_success` uses block timestamp `1647888693` and asserts `assertIn("Mar-22-2022", result)`, with the comment `# Tue Mar 22 2022 02:51:33 GMT+0000`.

`1647888693` is actually **Mon Mar 21 2022 18:51:33 UTC**. `Mar 22 2022 02:51:33` is that instant in **UTC+8** — the comment labels an author-local rendering as GMT. As a result the suite only passes from about UTC+6 eastward:

```
=== before this PR ===
TZ=UTC                 FAILED (failures=1)
TZ=Asia/Taipei         OK
TZ=America/New_York    FAILED (failures=1)
TZ=Europe/Berlin       FAILED (failures=1)
```

## Fix

- `datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)` — block timestamps rendered as UTC.
- The test's expectation corrected to the real UTC value (`Mar-21-2022 06:51:33 PM`) and tightened from `assertIn` to `assertEqual`, plus the misleading comment fixed.
- The `datetime.now()` fallbacks (used when no tx hash / no timestamp is given) routed through a small `utc_now()` helper, for the same reason. It returns a naive datetime, so every existing `strftime`/`strptime` path is unchanged.

```
=== after this PR ===
TZ=UTC                 Ran 53 tests  OK
TZ=Asia/Taipei         Ran 53 tests  OK
TZ=America/New_York    Ran 53 tests  OK
TZ=Pacific/Kiritimati  Ran 53 tests  OK
```

The existing `20250918 NGP` entry is left alone — happy to correct it in this PR if you'd like.