### PR TITLE
Add Telem to Hacks Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1810,7 +1810,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 ### Hacks Dashboard
 
-[Slowmist](https://hacked.slowmist.io/) | [Defillama](https://defillama.com/hacks) | [De.Fi](https://de.fi/rekt-database) | [Rekt](https://rekt.news/) | [Cryptosec](https://cryptosec.info/defi-hacks/) | [BlockSec](https://app.blocksec.com/explorer/security-incidents)
+[Slowmist](https://hacked.slowmist.io/) | [Defillama](https://defillama.com/hacks) | [De.Fi](https://de.fi/rekt-database) | [Rekt](https://rekt.news/) | [Cryptosec](https://cryptosec.info/defi-hacks/) | [BlockSec](https://app.blocksec.com/explorer/security-incidents) | [Telem](https://telem.news/security/incidents)
 
 ---
 ### List of DeFi Hacks & POCs


### PR DESCRIPTION
Adding Telem to the Hacks Dashboard list — a continuously updated incident feed of DeFi exploits, hacks and rug pulls (date, protocol, and an original attributed brief per incident): https://telem.news/security/incidents

I run Telem. It's free, no login, no paywall — same class of resource as the Slowmist/DefiLlama/Rekt dashboards already listed. Happy to adjust placement or format.