### PR TITLE
Fix MetaPool (20250617) category: infinite mint, not access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ If you appreciate our work, please consider donating. Even a small amount helps 
 
 [20250618 BankrollStackPlus](past/2025/README.md#20250618-bankrollstackplus---incorrect-dividends-calculation)
 
-[20250617 MetaPool](past/2025/README.md#20250617-metapool---access-control)
+[20250617 MetaPool](past/2025/README.md#20250617-metapool---infinite-mint-via-unvalidated-erc4626-mint)
 
 [20250615 WaleCoin](past/2025/README.md#20250615-walecoin---access-control)
 

--- a/past/2025/README.md
+++ b/past/2025/README.md
@@ -1209,7 +1209,7 @@ https://t.me/defimon_alerts/1301
 
 ---
 
-### 20250617 MetaPool - Access Control
+### 20250617 MetaPool - Infinite Mint via unvalidated ERC4626 mint
 
 ### Lost: 25k USD
 


### PR DESCRIPTION
## Summary
The 2025-06-17 Meta Pool entry is labeled **Access Control**, but the vulnerability is a share-accounting / infinite-mint bug.

- `mint()` on mpETH (`0x48afbbd342f64ef8a9ab1c143719b63c2ad81710`) is a public ERC-4626 entry point that anyone is meant to call; no privileged role was bypassed.
- The ETH-receipt check had been moved out of the internal `_deposit` into `deposit()`, but `mint()` also routes through `_deposit`, so `mint()` credited shares without receiving any ETH.
- The repo's own PoC (`src/test/2025-06/MetaPool_exp.sol`, step 3) simply calls `mpEth.mint(amount, address(this))` with no value attached and receives ~97 mpETH for free.
- Other trackers agree: DeFiLlama classifies it as *Token & Share Accounting / Infinite Mint*; CyberChainBench (bench-465) as *accounting-error* in `mint`.

## Changes
- `past/2025/README.md`: retitle the entry to `MetaPool - Infinite Mint via unvalidated ERC4626 mint`.
- `README.md`: update the incident-list anchor to match.

No PoC code changes.

Doscovered by Claude but validated by myself. 